### PR TITLE
proto actor initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 
 [dependencies]
 crossbeam-channel = "0.5"
+prost = "0.11"
+prost-types = "0.11"
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,12 @@ edition = "2021"
 
 [dependencies]
 crossbeam-channel = "0.5"
+log = "0.4"
 prost = "0.11"
 prost-types = "0.11"
+
+[build-dependencies]
+prost-build = "0.11"
 
 
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+use std::io::Result;
+fn main() -> Result<()> {
+    println!("running");
+    prost_build::compile_protos(
+        &["examples/hello_world/hello_world.proto"],
+        &["examples/hello_world/"],
+    )?;
+    Ok(())
+}

--- a/examples/hello_world/hello_world.proto
+++ b/examples/hello_world/hello_world.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package hello_world;
+
+message actor {
+  message init {
+    string greeting = 1;
+  }
+}

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -1,22 +1,48 @@
 extern crate busan;
 
-use busan::actor::Actor;
+use busan::actor::{Actor, ActorInit};
 use busan::system::ActorSystem;
+
+pub mod hello_world {
+    include!(concat!(env!("OUT_DIR"), "/hello_world.rs"));
+}
 
 fn main() {
     let system = ActorSystem::init();
-    system.spawn_actor::<Greet>("greeter".to_string());
-
+    let mut init = hello_world::actor::Init::default();
+    init.greeting = "Hi there!".to_string();
+    system.spawn_root_actor::<_, Greet>("greeter".to_string(), &init);
     system.wait_shutdown();
 }
 
-struct Greet {}
-impl Actor for Greet {
-    fn init() -> Self
-    where
-        Self: Sized,
-    {
-        println!("Hello, init()!");
-        Greet {}
+struct Greet {
+    greeting: String,
+}
+
+impl ActorInit for Greet {
+    type Init = hello_world::actor::Init;
+
+    fn init(init_msg: &Self::Init) -> Self {
+        println!("spawning greet actor");
+        Greet {
+            greeting: init_msg.greeting.clone(),
+        }
     }
+}
+
+impl Actor for Greet {
+    // fn init(init_msg: &dyn prost::Message) -> Self
+    // where
+    //     Self: Sized,
+    // {
+    //     if let &hello_world::actor::Init { greeting } = init_msg {
+    //         println("{}", init_msg.name);
+    //         return Greet {
+    //             greeting: init_msg.name.clone(),
+    //         };
+    //     }
+    //     Greet {
+    //         greeting: "Hello, world".to_string(),
+    //     }
+    // }
 }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,17 +1,34 @@
 /// place-holder trait for an actor, this might change at some point
 pub trait Actor: Send {
-    fn init() -> Self
-    where
-        Self: Sized;
+    // fn init(init_msg: &dyn prost::Message) -> Self
+    // where
+    //     Self: Sized;
 }
+
+// TODO: this name sucks
+pub trait ActorInit {
+    type Init: prost::Message;
+
+    fn init(init_msg: &Self::Init) -> Self
+    where
+        Self: Sized + Actor;
+}
+
+// TODO:
+//   1. Make an actor-creator/actor-initializer/actor-factory trait that contains the type
+//      that is initializes the actor and holds the init method that is called wit the
+//      correct type.
+// NOTE:
+//   - Sending messages should always be a prost::Message
+//   - Receiving messages could be an Any type which _should_ allow for better pattern matching
+//     against expected types. See:
+//     https://stackoverflow.com/questions/26126683/how-to-match-trait-implementors
 
 /// thing that couples the actor and the mailbox together
 pub struct ActorCell {
     actor: Box<dyn Actor>,
-    mailbox: Vec<Message>,
+    mailbox: Vec<Box<dyn prost::Message>>,
 }
-
-pub type Message = String;
 
 pub struct ActorAddress {
     pub name: String,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -14,7 +14,7 @@ pub trait ExecutorFactory {
     fn spawn_executor(&self, name: String) -> Sender<ExecutorCommands>;
 }
 
-pub trait ExecutionContext {
+pub trait Executor {
     fn run(&mut self, receiver: Receiver<ExecutorCommands>);
-    fn spawn_actor<A: Actor + 'static>(&mut self, name: String) -> ActorAddress;
+    // fn spawn_actor<A: Actor + 'static>(&mut self, name: String) -> ActorAddress;
 }


### PR DESCRIPTION
This change introduces a protobuf library to use with actor initialization
(and eventually message sending). Currently going with `prost`, although
this may change in the future if we decide that more reflection is needed.
Or possibly some additional generation will be needed, we'll see.

With proper message types we can add actor initialization. We rely on the
same type for messages here to help encourage accidental state sharing
on initialization. This will make more sense once the `debug_serialize!`
macro is added.