### PR TITLE
Add GitHub Workflows support for some basic CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+concurrency:
+  # Cancel previous actions from the same PR: https://stackoverflow.com/a/72408109
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: [check]
     steps:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
@@ -56,6 +57,7 @@ jobs:
   lints:
     name: Lints
     runs-on: ubuntu-latest
+    needs: [check]
     steps:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
@@ -78,4 +80,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: -- -W warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,3 +33,49 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  protoc:
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v1
+
   check:
     name: Check
     runs-on: ubuntu-latest
+    needs: [protoc]
     steps:
       - uses: actions/checkout@v3
       - name: Install stable toolchain

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,11 @@ concurrency:
 
 jobs:
   protoc:
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
 
   check:
     name: Check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   protoc:
-    name: Check
+    name: Install protobuf
     runs-on: ubuntu-latest
     steps:
       - name: Install Protoc
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [protoc]
     steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
       - uses: actions/checkout@v3
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,20 +15,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  protoc:
-    name: Install protobuf
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-
   check:
     name: Check
     runs-on: ubuntu-latest
-    needs: [protoc]
     steps:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
### Summary

Adds a GH workflow for some basic CI tests, specifically it adds:
  + `cargo check` - does the lib and all the examples compile okay
  + `cargo test` - runs tests
  + `cargo clippy` - linter for code-quality

Since things are still very much in the prototype'y phase, the linter
is set to allow warnings. Does clippy emit higher values than that?
Anyways, once things become more mature, we can circle back to turning
this on and making it more aggressive (and probably a giant
refactor/cleanup when that happens)

### Motivation

CI is a good thing? A nice status badge is cool.

### Test Plan

This _is_ the test plan.