### PR TITLE
Implement system shutdown (properly)

### DIFF
--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -12,7 +12,7 @@ fn main() {
     let mut init = hello_world::actor::Init::default();
     init.greeting = "Hi there!".to_string();
     system.spawn_root_actor::<_, Greet>("greeter".to_string(), &init);
-    system.wait_shutdown();
+    system.shutdown();
 }
 
 struct Greet {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,6 +1,6 @@
 use crossbeam_channel::{Receiver, Sender};
 
-use crate::actor::{Actor, ActorAddress};
+use crate::actor::Actor;
 
 pub enum ExecutorCommands {
     SpawnActor(Box<dyn Actor>, String),
@@ -11,10 +11,35 @@ pub enum ExecutorCommands {
 pub trait ExecutorFactory {
     // Spawn an executor with a given name. Tha name will be used by the
     // executor for routing messages to the correct actor.
-    fn spawn_executor(&self, name: String) -> Sender<ExecutorCommands>;
+    fn spawn_executor(&self, name: String) -> ExecutorHandle;
 }
 
 pub trait Executor {
     fn run(&mut self, receiver: Receiver<ExecutorCommands>);
     // fn spawn_actor<A: Actor + 'static>(&mut self, name: String) -> ActorAddress;
+}
+
+/// ExecutorHandle contains all the context necessary for the control-thread, which
+/// amounts to a channel to send commands through and a way to close or await closing
+/// of the executor.
+pub struct ExecutorHandle {
+    pub sender: Sender<ExecutorCommands>,
+    close_fn: Box<dyn FnOnce() -> ()>,
+}
+
+impl ExecutorHandle {
+    pub fn new<F: FnOnce() -> () + 'static>(
+        sender: Sender<ExecutorCommands>,
+        close_fn: F,
+    ) -> ExecutorHandle {
+        ExecutorHandle {
+            sender,
+            close_fn: Box::new(close_fn),
+        }
+    }
+
+    /// Close the executor handle. Note that this can only be called once and consumes itself.
+    pub fn close(self) {
+        (self.close_fn)();
+    }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -39,7 +39,7 @@ impl ExecutorHandle {
     }
 
     /// Close the executor handle. Note that this can only be called once and consumes itself.
-    pub fn close(self) {
+    pub fn await_close(self) {
         (self.close_fn)();
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -59,16 +59,19 @@ impl ActorSystem {
     }
 
     /// Send shutdown message to all executors and wait for them to finish
-    pub fn wait_shutdown(self) {
-        thread::sleep(Duration::from_millis(1000));
-
+    pub fn shutdown(self) {
         for (_, executor) in self.executors.iter() {
             executor.sender.send(ExecutorCommands::Shutdown).unwrap();
         }
-        self.executors.into_iter().for_each(|(_, executor)| {
-            executor.close();
-        });
+        self.await_shutdown();
+    }
 
-        thread::sleep(Duration::from_millis(10_000));
+    /// Await shutdown of all executors. Similar to shutdown, but doesn't send
+    /// shutdown messages to begin shutdown. Will wait indefinitely until all
+    /// executors have shutdown.
+    pub fn await_shutdown(self) {
+        self.executors
+            .into_iter()
+            .for_each(|(_, executor)| executor.await_close());
     }
 }


### PR DESCRIPTION
### Summary

+ Refactors the return handle of the executor factory (previously just a
  `Sender<ExecutorCommand>`) to be a struct that encapsulates the close
  functionality via a `FnOnce`.
+ Implement closing for the existing thread-based executors via
  `thread::JoinHandle::join()`
+ Add `await_shutdown()` to the system, which simply calls the `await_close`
  method on the `ExecutorHandle`, but doesn't send the command to indicate
  a shutdown. This is essentially something that could be called in a `main`
  function for a process you want to run indefinitely.

### Motivation

Resolve #8 

### Test Plan

Currently no tests 😢, just banking on the fact that this compiles. More
comprehensive testing will come at a later stage.