### PR TITLE
add cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v2
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
@@ -49,6 +50,7 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v2
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
@@ -69,6 +71,7 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
### Summary

Add per-job caching to CI using swatinem/ruts-cache.

### Motivation

  + Faster builds (and hopefully less load on github CI)
  + Resolves #7 

### Test Plan

  + CI should pass as normal
  + Manually re-ran CI jobs to observe successful cache behavior

Don't have a great way of seeing how this will do across multiple branches and, being for a library, may have limited effectiveness. So this will have to be something I observe over time and ensure it's behaving in an effective way.