### PR TITLE
Basic child-actor creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ repository = "https://github.com/JohnMurray/busan"
 keywords = ["actor", "actors", "actor-system", "concurrent", "concurrency"]
 authors = ["John Murray"]
 
+autoexamples = false
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -26,6 +28,10 @@ prost-build = "0.11"
 ## --------------------------------------------------------------------------------
 ## Examples
 
-[[bin]]
+[[example]]
 name = "hello_world"
 path = "examples/hello_world/main.rs"
+
+[[example]]
+name = "ping_pong"
+path = "examples/ping_pong/main.rs"

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -2,6 +2,7 @@ extern crate busan;
 
 use busan::actor::{Actor, ActorInit};
 use busan::system::ActorSystem;
+use std::thread;
 
 pub mod hello_world {
     include!(concat!(env!("OUT_DIR"), "/hello_world.rs"));
@@ -12,6 +13,8 @@ fn main() {
     let mut init = hello_world::actor::Init::default();
     init.greeting = "Hi there!".to_string();
     system.spawn_root_actor::<_, Greet>("greeter".to_string(), &init);
+
+    thread::sleep(std::time::Duration::from_secs(1));
     system.shutdown();
 }
 
@@ -31,18 +34,7 @@ impl ActorInit for Greet {
 }
 
 impl Actor for Greet {
-    // fn init(init_msg: &dyn prost::Message) -> Self
-    // where
-    //     Self: Sized,
-    // {
-    //     if let &hello_world::actor::Init { greeting } = init_msg {
-    //         println("{}", init_msg.name);
-    //         return Greet {
-    //             greeting: init_msg.name.clone(),
-    //         };
-    //     }
-    //     Greet {
-    //         greeting: "Hello, world".to_string(),
-    //     }
-    // }
+    fn before_start(&mut self, _ctx: busan::actor::Context) {
+        println!("{}", self.greeting);
+    }
 }

--- a/examples/ping_pong/main.rs
+++ b/examples/ping_pong/main.rs
@@ -1,0 +1,45 @@
+extern crate busan;
+
+use busan::actor::{Actor, ActorInit, Context};
+use busan::system::ActorSystem;
+
+struct Ping {}
+struct Pong {}
+
+impl ActorInit for Ping {
+    type Init = ();
+
+    fn init(_init_msg: &Self::Init) -> Self
+    where
+        Self: Sized + Actor,
+    {
+        println!("init ping");
+        Ping {}
+    }
+}
+
+impl ActorInit for Pong {
+    type Init = ();
+
+    fn init(_init_msg: &Self::Init) -> Self
+    where
+        Self: Sized + Actor,
+    {
+        println!("init pong");
+        Pong {}
+    }
+}
+
+impl Actor for Ping {
+    fn before_start(&mut self, ctx: Context) {
+        ctx.spawn_child::<_, Pong>("pong".to_string(), &());
+    }
+}
+impl Actor for Pong {}
+
+fn main() {
+    let system = ActorSystem::init();
+    system.spawn_root_actor::<_, Ping>("ping".to_string(), &());
+
+    system.await_shutdown();
+}

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,11 +1,17 @@
+use crate::executor::Executor;
+
 /// place-holder trait for an actor, this might change at some point
 pub trait Actor: Send {
     // fn init(init_msg: &dyn prost::Message) -> Self
     // where
     //     Self: Sized;
+
+    fn before_start(&mut self, _ctx: Context) {}
 }
 
-// TODO: this name sucks
+/// ActorInit defines a method of construction for an actor that takes an initialization
+/// message. This provides type-safe initialization of an actor while keeping construction
+/// and internal state within the actor system.
 pub trait ActorInit {
     type Init: prost::Message;
 
@@ -14,22 +20,47 @@ pub trait ActorInit {
         Self: Sized + Actor;
 }
 
-// TODO:
-//   1. Make an actor-creator/actor-initializer/actor-factory trait that contains the type
-//      that is initializes the actor and holds the init method that is called wit the
-//      correct type.
 // NOTE:
 //   - Sending messages should always be a prost::Message
 //   - Receiving messages could be an Any type which _should_ allow for better pattern matching
 //     against expected types. See:
 //     https://stackoverflow.com/questions/26126683/how-to-match-trait-implementors
 
-/// thing that couples the actor and the mailbox together
-pub struct ActorCell {
+/// ActorCell is the wrapper to the user-defined actor, wrapping the mailbox parent references,
+/// and other actor-related information that is useful internally.
+pub(crate) struct ActorCell {
+    parent: Option<ActorAddress>,
     actor: Box<dyn Actor>,
     mailbox: Vec<Box<dyn prost::Message>>,
 }
 
+impl ActorCell {}
+
+/// Actor context object used for performing actions that interact with the running
+/// actor-system, such as spawning new actors.
+pub struct Context<'a> {
+    executor: &'a mut dyn Executor,
+}
+
+impl Context<'_> {
+    pub fn new(executor: &mut dyn Executor) -> Context {
+        Context { executor }
+    }
+
+    /// Create a new (child) actor. Note that this may be a delayed action and the actor
+    /// may not be created immediately.
+    pub fn spawn_child<B, A: ActorInit<Init = B> + Actor + 'static>(
+        &self,
+        name: String,
+        init_msg: &B,
+    ) -> ActorAddress {
+        self.executor
+            .assign_actor(Box::new(A::init(init_msg)), name.clone());
+        self.executor.get_address(&name)
+    }
+}
+
+#[derive(Clone)]
 pub struct ActorAddress {
     pub name: String,
     pub executor_name: String,

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -2,10 +2,10 @@ pub(crate) mod thread_executor;
 
 use crossbeam_channel::{Receiver, Sender};
 
-use crate::actor::Actor;
+use crate::actor::{Actor, ActorAddress};
 
 pub enum ExecutorCommands {
-    SpawnActor(Box<dyn Actor>, String),
+    AssignActor(Box<dyn Actor>, String),
     Shutdown,
 }
 
@@ -17,7 +17,15 @@ pub trait ExecutorFactory {
 }
 
 pub trait Executor {
-    fn run(&mut self, receiver: Receiver<ExecutorCommands>);
+    fn run(self, receiver: Receiver<ExecutorCommands>);
+
+    // Given the name of an actor, return the address local to the executor
+    fn get_address(&self, actor_name: &str) -> ActorAddress;
+
+    // Given an actor, assign the actor to the executor. Note that the implementation
+    // does not require immediate assignment and there may be some delay based on
+    // the particular executor implementation.
+    fn assign_actor(&self, actor: Box<dyn Actor>, name: String);
 }
 
 /// ExecutorHandle contains all the context necessary for the control-thread, which

--- a/src/executor/thread_executor.rs
+++ b/src/executor/thread_executor.rs
@@ -1,10 +1,10 @@
-use crossbeam_channel::{bounded, Receiver};
-use log::trace;
+use crossbeam_channel::{bounded, Receiver, Sender};
+use log::{debug, trace};
 use std::collections::HashMap;
 use std::thread;
 use std::time::Duration;
 
-use crate::actor::{Actor, ActorAddress};
+use crate::actor::{Actor, ActorAddress, Context};
 use crate::executor::{Executor, ExecutorCommands, ExecutorFactory, ExecutorHandle};
 
 const COMMAND_BUFFER_SIZE: usize = 32;
@@ -13,10 +13,12 @@ pub struct ThreadExecutorFactory {}
 impl ExecutorFactory for ThreadExecutorFactory {
     fn spawn_executor(&self, name: String) -> ExecutorHandle {
         let (sender, receiver) = bounded::<ExecutorCommands>(COMMAND_BUFFER_SIZE);
+        let sender_copy = sender.clone();
         let t = thread::spawn(move || {
             ThreadExecutor {
                 name,
                 actors: HashMap::new(),
+                sender: sender_copy,
             }
             .run(receiver)
         });
@@ -25,36 +27,45 @@ impl ExecutorFactory for ThreadExecutorFactory {
 }
 
 /// thread-local executor responsible for processing messages on actors
-pub struct ThreadExecutor {
+struct ThreadExecutor {
     // Name of the executor, which is part of the address to actors and used
     // for routing decisions
     name: String,
 
-    // map of actor names to actors
-    // the "name" is part of the address
+    // map of actor names to actors where the key (actor name) is part of the address-to-actor
+    // resolution
     actors: HashMap<String, Box<dyn Actor>>,
+
+    // Handle for sending commands to the current executor. Useful for spawning new actors
+    // on the main event loop, or any action that may need to be performed in a slightly
+    // delayed manner.
+    sender: Sender<ExecutorCommands>,
 }
 impl ThreadExecutor {
-    fn get_address(&self, actor_name: &str) -> ActorAddress {
-        ActorAddress {
-            name: actor_name.to_string(),
-            executor_name: self.name.clone(),
+    /// Utility function for ensuring that the name of an actor is unique. Useful before
+    /// inserting a new entry in the actor store (when creating actors).
+    fn assert_name_unique(&self, name: &str) {
+        if self.actors.contains_key(name) {
+            panic!("Actor name {} already exists", name);
         }
     }
 }
 impl Executor for ThreadExecutor {
-    fn run(&mut self, receiver: Receiver<ExecutorCommands>) {
-        const SLEEP_DURATION_MS: u64 = 10;
+    fn run(mut self, receiver: Receiver<ExecutorCommands>) {
+        const SLEEP_DURATION_MS: u64 = 1;
 
         loop {
             if !receiver.is_empty() {
                 match receiver.recv().unwrap() {
-                    ExecutorCommands::SpawnActor(actor, name) => {
-                        self.actors.insert(name, actor);
-                        trace!("received spawn actor command");
+                    ExecutorCommands::AssignActor(mut actor, name) => {
+                        debug!("received assign-root-actor command for actor {}", name);
+                        self.assert_name_unique(&name);
+                        trace!("calling before_start for actor {}", name);
+                        actor.before_start(Context::new(&mut self));
+                        self.actors.insert(name.clone(), actor);
                     }
                     ExecutorCommands::Shutdown => {
-                        trace!("received shutdown command");
+                        debug!("received shutdown command");
                         break;
                     }
                 }
@@ -65,8 +76,21 @@ impl Executor for ThreadExecutor {
         }
     }
 
-    // fn spawn_actor<A: Actor + 'static>(&mut self, name: String) -> ActorAddress {
-    //     self.actors.insert(name.clone(), Box::new(A::init()));
-    //     self.get_address(&name)
-    // }
+    fn get_address(&self, actor_name: &str) -> ActorAddress {
+        ActorAddress {
+            name: actor_name.to_string(),
+            executor_name: self.name.clone(),
+        }
+    }
+
+    fn assign_actor(&self, actor: Box<dyn Actor>, name: String) {
+        // TODO: this should be a non-blocking send to avoid dead-locking on a full
+        //       command-queue.
+        // However, need to think about how to allow for many actors to be created and used
+        // within a single actor loop. :thinkies:
+        // XXX: For now, this means that creating + 'asking' an actor would be a deadlock
+        self.sender
+            .send(ExecutorCommands::AssignActor(actor, name))
+            .unwrap();
+    }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::thread;
-use std::time::Duration;
 
 use crate::actor::{Actor, ActorInit};
 use crate::executor::thread_executor::ThreadExecutorFactory;
@@ -51,7 +49,7 @@ impl ActorSystem {
             .get("executor-0")
             .unwrap()
             .sender
-            .send(ExecutorCommands::SpawnActor(
+            .send(ExecutorCommands::AssignActor(
                 Box::new(A::init(init_msg)),
                 name,
             ))


### PR DESCRIPTION
### Summary

This commit adds the ability of actors to spawn other actors given a context object that is internally wired up to the current executor. The title says "basic" for a few different reasons:

  + It is possible to create children in a loop and deadlock the executor
  + Children are created async and it's not currently possible to create + 'ask'
    without hittig a deadlock. (not that asking is supported yet anyways)
  + There is no link created between parent and child, because there is no lifecycle
    support and messages can't be sent anyways.

### Motivation

Resolves #9

### Test Plan

A new example was added that manually validates the new functionality.