### PR TITLE
Non-Blocking Actor Spawn

### DIFF
--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -9,9 +9,10 @@ pub mod hello_world {
 }
 
 fn main() {
-    let system = ActorSystem::init();
-    let mut init = hello_world::actor::Init::default();
-    init.greeting = "Hi there!".to_string();
+    let mut system = ActorSystem::init();
+    let init = hello_world::actor::Init {
+        greeting: "Hi there!".to_string(),
+    };
     system.spawn_root_actor::<_, Greet>("greeter".to_string(), &init);
 
     thread::sleep(std::time::Duration::from_secs(1));

--- a/examples/ping_pong/main.rs
+++ b/examples/ping_pong/main.rs
@@ -2,6 +2,7 @@ extern crate busan;
 
 use busan::actor::{Actor, ActorInit, Context};
 use busan::system::ActorSystem;
+use std::thread;
 
 struct Ping {}
 struct Pong {}
@@ -38,8 +39,9 @@ impl Actor for Ping {
 impl Actor for Pong {}
 
 fn main() {
-    let system = ActorSystem::init();
+    let mut system = ActorSystem::init();
     system.spawn_root_actor::<_, Ping>("ping".to_string(), &());
 
-    system.await_shutdown();
+    thread::sleep(std::time::Duration::from_secs(1));
+    system.shutdown();
 }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,42 +1,12 @@
 pub(crate) mod thread_executor;
 
-use crossbeam_channel::{Receiver, Sender};
-
 use crate::actor::{Actor, ActorAddress};
 use crate::system::RuntimeManagerRef;
+use crate::util::CommandChannel;
 
 pub enum ExecutorCommands {
     AssignActor(Box<dyn Actor>, String),
     Shutdown,
-}
-
-pub struct CommandChannel<T> {
-    pub(self) sender: Sender<T>,
-    pub(self) receiver: Receiver<T>,
-}
-
-impl<T> CommandChannel<T> {
-    pub fn new() -> CommandChannel<T> {
-        let (sender, receiver) = crossbeam_channel::unbounded();
-        CommandChannel { sender, receiver }
-    }
-
-    pub fn send(&self, command: T) -> Result<(), crossbeam_channel::SendError<T>> {
-        self.sender.send(command)
-    }
-
-    pub fn recv(&self) -> Result<T, crossbeam_channel::RecvError> {
-        self.receiver.recv()
-    }
-}
-
-impl<T> Clone for CommandChannel<T> {
-    fn clone(&self) -> Self {
-        CommandChannel {
-            sender: self.sender.clone(),
-            receiver: self.receiver.clone(),
-        }
-    }
 }
 
 /// responsible for creating an executor

--- a/src/executor/thread_executor.rs
+++ b/src/executor/thread_executor.rs
@@ -69,8 +69,8 @@ impl Executor for ThreadExecutor {
         const SLEEP_DURATION_MS: u64 = 1;
 
         loop {
-            if !self.command_channel.receiver.is_empty() {
-                match self.command_channel.receiver.recv().unwrap() {
+            if !self.command_channel.recv_is_empty() {
+                match self.command_channel.recv().unwrap() {
                     ExecutorCommands::AssignActor(mut actor, name) => {
                         debug!("received assign-root-actor command for actor {}", name);
                         self.assert_name_unique(&name);
@@ -106,7 +106,6 @@ impl Executor for ThreadExecutor {
         // within a single actor loop. :thinkies:
         // XXX: For now, this means that creating + 'asking' an actor would be a deadlock
         self.command_channel
-            .sender
             .send(ExecutorCommands::AssignActor(actor, name))
             .unwrap();
     }

--- a/src/executor/thread_executor.rs
+++ b/src/executor/thread_executor.rs
@@ -1,28 +1,25 @@
-use crossbeam_channel::{bounded, Receiver, Sender};
 use log::{debug, trace};
 use std::collections::HashMap;
 use std::thread;
 use std::time::Duration;
 
 use crate::actor::{Actor, ActorAddress, Context};
-use crate::executor::{Executor, ExecutorCommands, ExecutorFactory, ExecutorHandle};
-
-const COMMAND_BUFFER_SIZE: usize = 32;
+use crate::executor::{
+    CommandChannel, Executor, ExecutorCommands, ExecutorFactory, ExecutorHandle,
+};
+use crate::system::RuntimeManagerRef;
 
 pub struct ThreadExecutorFactory {}
 impl ExecutorFactory for ThreadExecutorFactory {
-    fn spawn_executor(&self, name: String) -> ExecutorHandle {
-        let (sender, receiver) = bounded::<ExecutorCommands>(COMMAND_BUFFER_SIZE);
-        let sender_copy = sender.clone();
-        let t = thread::spawn(move || {
-            ThreadExecutor {
-                name,
-                actors: HashMap::new(),
-                sender: sender_copy,
-            }
-            .run(receiver)
-        });
-        ExecutorHandle::new(sender, move || t.join().unwrap())
+    fn spawn_executor(
+        &self,
+        name: String,
+        command_channel: CommandChannel<ExecutorCommands>,
+        manager_ref: RuntimeManagerRef,
+    ) -> ExecutorHandle {
+        let t =
+            thread::spawn(move || ThreadExecutor::init(name, command_channel, manager_ref).run());
+        ExecutorHandle::new(move || t.join().unwrap())
     }
 }
 
@@ -39,9 +36,26 @@ struct ThreadExecutor {
     // Handle for sending commands to the current executor. Useful for spawning new actors
     // on the main event loop, or any action that may need to be performed in a slightly
     // delayed manner.
-    sender: Sender<ExecutorCommands>,
+    command_channel: CommandChannel<ExecutorCommands>,
+
+    // Handle for sending message to the manager. This is useful for coordinating system-wide
+    // actions such as shutting down the system, spawning new actors, etc.
+    runtime_manager: RuntimeManagerRef,
 }
 impl ThreadExecutor {
+    fn init(
+        name: String,
+        command_channel: CommandChannel<ExecutorCommands>,
+        runtime_manager: RuntimeManagerRef,
+    ) -> ThreadExecutor {
+        ThreadExecutor {
+            name,
+            actors: HashMap::new(),
+            command_channel,
+            runtime_manager,
+        }
+    }
+
     /// Utility function for ensuring that the name of an actor is unique. Useful before
     /// inserting a new entry in the actor store (when creating actors).
     fn assert_name_unique(&self, name: &str) {
@@ -51,12 +65,12 @@ impl ThreadExecutor {
     }
 }
 impl Executor for ThreadExecutor {
-    fn run(mut self, receiver: Receiver<ExecutorCommands>) {
+    fn run(mut self) {
         const SLEEP_DURATION_MS: u64 = 1;
 
         loop {
-            if !receiver.is_empty() {
-                match receiver.recv().unwrap() {
+            if !self.command_channel.receiver.is_empty() {
+                match self.command_channel.receiver.recv().unwrap() {
                     ExecutorCommands::AssignActor(mut actor, name) => {
                         debug!("received assign-root-actor command for actor {}", name);
                         self.assert_name_unique(&name);
@@ -74,6 +88,8 @@ impl Executor for ThreadExecutor {
             trace!("nothing to do, sleeping...");
             thread::sleep(Duration::from_millis(SLEEP_DURATION_MS));
         }
+
+        self.runtime_manager.notify_shutdown(self.name);
     }
 
     fn get_address(&self, actor_name: &str) -> ActorAddress {
@@ -89,7 +105,8 @@ impl Executor for ThreadExecutor {
         // However, need to think about how to allow for many actors to be created and used
         // within a single actor loop. :thinkies:
         // XXX: For now, this means that creating + 'asking' an actor would be a deadlock
-        self.sender
+        self.command_channel
+            .sender
             .send(ExecutorCommands::AssignActor(actor, name))
             .unwrap();
     }

--- a/src/executor/thread_executor.rs
+++ b/src/executor/thread_executor.rs
@@ -100,13 +100,6 @@ impl Executor for ThreadExecutor {
     }
 
     fn assign_actor(&self, actor: Box<dyn Actor>, name: String) {
-        // TODO: this should be a non-blocking send to avoid dead-locking on a full
-        //       command-queue.
-        // However, need to think about how to allow for many actors to be created and used
-        // within a single actor loop. :thinkies:
-        // XXX: For now, this means that creating + 'asking' an actor would be a deadlock
-        self.command_channel
-            .send(ExecutorCommands::AssignActor(actor, name))
-            .unwrap();
+        self.runtime_manager.assign_actor(actor, name);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod actor;
 pub mod executor;
 pub mod system;
+pub mod util;

--- a/src/system.rs
+++ b/src/system.rs
@@ -4,7 +4,8 @@ use std::thread;
 
 use crate::actor::{Actor, ActorInit};
 use crate::executor::thread_executor::ThreadExecutorFactory;
-use crate::executor::{CommandChannel, ExecutorCommands, ExecutorFactory, ExecutorHandle};
+use crate::executor::{ExecutorCommands, ExecutorFactory, ExecutorHandle};
+use crate::util::CommandChannel;
 
 const NUM_EXECUTORS: usize = 4;
 
@@ -153,7 +154,7 @@ impl RuntimeManager {
 
     fn get_next_executor(&mut self) -> String {
         let mut iter = self.executor_command_channels.iter();
-        if self.rohnd_robin_state >= iter.len() {
+        if self.round_robin_state >= iter.len() {
             self.round_robin_state = 0;
         }
         iter.nth(self.round_robin_state).unwrap().0.clone()

--- a/src/system.rs
+++ b/src/system.rs
@@ -216,7 +216,7 @@ impl RuntimeManagerRef {
     /// Request that a new actor be assigned to a runtime executor. This may be called when assigning
     /// either a root actor or a child actor. This should be used to avoid blocking actor creation
     /// on a single executor.
-    pub fn assign_actor<A: Actor + 'static>(&self, actor: Box<A>, name: String) {
+    pub fn assign_actor(&self, actor: Box<dyn Actor>, name: String) {
         self.manager_command_channel
             .send(ManagerCommands::AssignActor(actor, name))
             .unwrap();

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,8 +1,10 @@
+use log::debug;
 use std::collections::HashMap;
+use std::thread;
 
 use crate::actor::{Actor, ActorInit};
 use crate::executor::thread_executor::ThreadExecutorFactory;
-use crate::executor::{ExecutorCommands, ExecutorFactory, ExecutorHandle};
+use crate::executor::{CommandChannel, ExecutorCommands, ExecutorFactory, ExecutorHandle};
 
 const NUM_EXECUTORS: usize = 4;
 
@@ -10,33 +12,47 @@ const NUM_EXECUTORS: usize = 4;
 pub struct ActorSystem {
     executor_factory: Box<dyn ExecutorFactory>,
     executors: HashMap<String, ExecutorHandle>,
+    runtime_manager: RuntimeManagerRef,
+    runtime_thread_handle: thread::JoinHandle<()>,
+    root_actor_assigned: bool,
 }
 
 impl ActorSystem {
     pub fn init() -> ActorSystem {
-        // create a mutable actor system with a thread executor factory
-        let mut system = ActorSystem {
-            executor_factory: Box::new(ThreadExecutorFactory {}),
-            executors: HashMap::new(),
-        };
+        let mut runtime_manager = RuntimeManager::init();
+        let executor_factory = Box::new(ThreadExecutorFactory {});
+        let mut executors = HashMap::new();
 
         // create a pre-configured number of executors
         for i in 0..NUM_EXECUTORS {
-            system.executors.insert(
-                format!("executor-{}", i),
-                system
-                    .executor_factory
-                    .spawn_executor(format!("executor-{}", i)),
+            let command_channel = CommandChannel::new();
+            let executor_name = format!("executor-{}", i);
+            let executor_handle = executor_factory.spawn_executor(
+                executor_name.clone(),
+                command_channel.clone(),
+                runtime_manager.get_ref(),
             );
+
+            executors.insert(executor_name.clone(), executor_handle);
+            runtime_manager.add_executor(executor_name.clone(), command_channel);
         }
 
-        system
+        let runtime_manager_ref = runtime_manager.get_ref();
+        let runtime_thread_handle = thread::spawn(move || {
+            runtime_manager.run();
+        });
+
+        ActorSystem {
+            executor_factory,
+            executors,
+            runtime_manager: runtime_manager_ref,
+            runtime_thread_handle,
+            root_actor_assigned: false,
+        }
     }
 
-    // TODO: rename to root-actor only (or update to rotate through executors)
-    // TODO: If for root actor only, create lock to prevent multiple root actors
     pub fn spawn_root_actor<B, A: ActorInit<Init = B> + Actor + 'static>(
-        &self,
+        &mut self,
         name: String,
         init_msg: &B,
     ) {
@@ -44,23 +60,16 @@ impl ActorSystem {
             self.executors.len() > 0,
             "No executors available to spawn actor"
         );
+        debug_assert!(!self.root_actor_assigned, "Root actor already assigned");
 
-        self.executors
-            .get("executor-0")
-            .unwrap()
-            .sender
-            .send(ExecutorCommands::AssignActor(
-                Box::new(A::init(init_msg)),
-                name,
-            ))
-            .unwrap()
+        self.root_actor_assigned = true;
+        self.runtime_manager
+            .assign_actor(Box::new(A::init(init_msg)), name);
     }
 
     /// Send shutdown message to all executors and wait for them to finish
     pub fn shutdown(self) {
-        for (_, executor) in self.executors.iter() {
-            executor.sender.send(ExecutorCommands::Shutdown).unwrap();
-        }
+        self.runtime_manager.shutdown_system();
         self.await_shutdown();
     }
 
@@ -70,6 +79,121 @@ impl ActorSystem {
     pub fn await_shutdown(self) {
         self.executors
             .into_iter()
-            .for_each(|(_, executor)| executor.await_close());
+            .for_each(|(_, manager)| manager.await_close());
+        self.runtime_thread_handle.join().unwrap();
     }
+}
+
+struct RuntimeManager {
+    /// Map of executor names to their command-channel (for sending commands)
+    executor_command_channels: HashMap<String, CommandChannel<ExecutorCommands>>,
+
+    manager_command_channel: CommandChannel<ManagerCommands>,
+
+    round_robin_state: usize,
+    shutdown_initiated: bool,
+}
+
+impl RuntimeManager {
+    fn init() -> RuntimeManager {
+        RuntimeManager {
+            executor_command_channels: HashMap::new(),
+            manager_command_channel: CommandChannel::new(),
+            round_robin_state: 0,
+            shutdown_initiated: false,
+        }
+    }
+
+    fn add_executor(&mut self, name: String, command_channel: CommandChannel<ExecutorCommands>) {
+        self.executor_command_channels.insert(name, command_channel);
+    }
+
+    fn get_ref(&self) -> RuntimeManagerRef {
+        RuntimeManagerRef::new(self.manager_command_channel.clone())
+    }
+
+    fn run(mut self) {
+        loop {
+            match self.manager_command_channel.recv() {
+                Ok(ManagerCommands::Shutdown) => {
+                    if self.shutdown_initiated {
+                        continue;
+                    }
+                    self.shutdown_initiated = true;
+                    self.executor_command_channels
+                        .iter()
+                        .for_each(|(_, channel)| {
+                            channel.send(ExecutorCommands::Shutdown).unwrap();
+                        });
+                }
+
+                // TODO: Actually send this message from the Executors
+                Ok(ManagerCommands::ExecutorShutdown { name }) => {
+                    if self.executor_command_channels.contains_key(&name) {
+                        self.executor_command_channels.remove(&name);
+                        if self.executor_command_channels.len() == 0 {
+                            break;
+                        }
+                    }
+                }
+                Ok(ManagerCommands::AssignActor(actor, name)) => {
+                    let executor_name = self.get_next_executor();
+                    self.executor_command_channels
+                        .get(&executor_name)
+                        .unwrap()
+                        .send(ExecutorCommands::AssignActor(actor, name))
+                        .unwrap();
+                }
+                Err(_) => {}
+            }
+        }
+
+        debug!("Runtime manager shutting down");
+    }
+
+    fn get_next_executor(&mut self) -> String {
+        let mut iter = self.executor_command_channels.iter();
+        if self.rohnd_robin_state >= iter.len() {
+            self.round_robin_state = 0;
+        }
+        iter.nth(self.round_robin_state).unwrap().0.clone()
+    }
+}
+
+pub struct RuntimeManagerRef {
+    manager_command_channel: CommandChannel<ManagerCommands>,
+}
+
+impl RuntimeManagerRef {
+    fn new(manager_command_channel: CommandChannel<ManagerCommands>) -> RuntimeManagerRef {
+        RuntimeManagerRef {
+            manager_command_channel,
+        }
+    }
+
+    pub fn shutdown_system(&self) {
+        self.manager_command_channel
+            .send(ManagerCommands::Shutdown)
+            .unwrap();
+    }
+
+    pub fn notify_shutdown(&self, executor_name: String) {
+        self.manager_command_channel
+            .send(ManagerCommands::ExecutorShutdown {
+                name: executor_name,
+            })
+            .unwrap();
+    }
+
+    pub fn assign_actor<A: Actor + 'static>(&self, actor: Box<A>, name: String) {
+        self.manager_command_channel
+            .send(ManagerCommands::AssignActor(actor, name))
+            .unwrap();
+    }
+}
+
+enum ManagerCommands {
+    Shutdown,
+    ExecutorShutdown { name: String },
+    AssignActor(Box<dyn Actor>, String),
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,8 @@
 use crossbeam_channel::{Receiver, Sender};
 
+/// A simple wrapper around channels to abstract out the specific channel implementation
+/// being used for sending and receiving. This ideally should be the only module that
+/// import anything from crossbeam_channel.
 pub struct CommandChannel<T> {
     pub(self) sender: Sender<T>,
     pub(self) receiver: Receiver<T>,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,34 @@
+use crossbeam_channel::{Receiver, Sender};
+
+pub struct CommandChannel<T> {
+    pub(self) sender: Sender<T>,
+    pub(self) receiver: Receiver<T>,
+}
+
+impl<T> CommandChannel<T> {
+    pub fn new() -> CommandChannel<T> {
+        let (sender, receiver) = crossbeam_channel::unbounded();
+        CommandChannel { sender, receiver }
+    }
+
+    pub fn send(&self, command: T) -> Result<(), crossbeam_channel::SendError<T>> {
+        self.sender.send(command)
+    }
+
+    pub fn recv(&self) -> Result<T, crossbeam_channel::RecvError> {
+        self.receiver.recv()
+    }
+
+    pub fn recv_is_empty(&self) -> bool {
+        self.receiver.is_empty()
+    }
+}
+
+impl<T> Clone for CommandChannel<T> {
+    fn clone(&self) -> Self {
+        CommandChannel {
+            sender: self.sender.clone(),
+            receiver: self.receiver.clone(),
+        }
+    }
+}


### PR DESCRIPTION
### Summary

+ Introduces a runtime manager for coordinating amongst executors
+ Updates executors to defer to runtime manager for actor assignment
+ Runtime manager assigns actors to executors based on round-robin strategy

Note: It's still possible for an executor to assign the actor back to the originating executor. Need to think on this if that's a problem for now-me or future-me.

### Motivation

Resolves #28

Per the changes introduced in #25, actor creation is currently a blocking operation. That is, an actor may create an actor and then perform work indefinitely in it's receive block, including sending messages to the created actor. Until the actor yields, the child actor would not be created.

This is not ideal, particularly when future patterns such as `ask` are introduced, this creates potential for deadlock.

Beyond this there are some other concerns that we're addressing:

  + Actors should be assigned against some sort of balancing strategy to make use of multiple executors (currently using a simple round-robin approach)
  + Mechanisms for moving actors across executors may be needed in the future for dynamic scheduling/balancing of actors

### Test Plan

Existing examples should continue to pass.