### PR TITLE
Implement address, address resolution, and actor-cell

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -105,7 +105,6 @@ impl ActorAddress {
         }
     }
 
-    // TODO: Implement resolution so this is actually used
     pub(crate) fn set_mailbox(&self, mailbox: Sender<Box<dyn prost::Message>>) {
         *self.mailbox.borrow_mut() = Some(mailbox);
     }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,11 +1,9 @@
-use crate::executor::Executor;
+use crate::system::RuntimeManagerRef;
+use crossbeam_channel::{Receiver, Sender};
+use std::cell::RefCell;
 
 /// place-holder trait for an actor, this might change at some point
 pub trait Actor: Send {
-    // fn init(init_msg: &dyn prost::Message) -> Self
-    // where
-    //     Self: Sized;
-
     fn before_start(&mut self, _ctx: Context) {}
 }
 
@@ -28,40 +26,87 @@ pub trait ActorInit {
 
 /// ActorCell is the wrapper to the user-defined actor, wrapping the mailbox parent references,
 /// and other actor-related information that is useful internally.
-pub(crate) struct ActorCell {
-    parent: Option<ActorAddress>,
-    actor: Box<dyn Actor>,
-    mailbox: Vec<Box<dyn prost::Message>>,
+pub struct ActorCell {
+    pub(crate) actor: Box<dyn Actor>,
+    pub(crate) mailbox: Receiver<Box<dyn prost::Message>>,
+    pub(crate) address: ActorAddress,
 }
 
-impl ActorCell {}
+impl ActorCell {
+    pub fn new(
+        actor: Box<dyn Actor>,
+        mailbox: Receiver<Box<dyn prost::Message>>,
+        address: ActorAddress,
+    ) -> Self {
+        Self {
+            actor,
+            mailbox,
+            address,
+        }
+    }
+}
 
 /// Actor context object used for performing actions that interact with the running
 /// actor-system, such as spawning new actors.
-pub struct Context<'a> {
-    executor: &'a mut dyn Executor,
+pub struct Context<'a, 'b> {
+    pub(crate) address: &'a ActorAddress,
+    pub(crate) runtime_manager: &'b RuntimeManagerRef,
 }
 
-impl Context<'_> {
-    pub fn new(executor: &mut dyn Executor) -> Context {
-        Context { executor }
-    }
-
+impl Context<'_, '_> {
     /// Create a new (child) actor. Note that this may be a delayed action and the actor
     /// may not be created immediately.
+    /// TODO: Ensure that actor names are unique
     pub fn spawn_child<B, A: ActorInit<Init = B> + Actor + 'static>(
         &self,
         name: String,
         init_msg: &B,
     ) -> ActorAddress {
-        self.executor
-            .assign_actor(Box::new(A::init(init_msg)), name.clone());
-        self.executor.get_address(&name)
+        let address = ActorAddress::new_child(self.address, &name);
+        self.runtime_manager
+            .assign_actor(Box::new(A::init(init_msg)), address.clone());
+        address
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug)]
 pub struct ActorAddress {
-    pub name: String,
-    pub executor_name: String,
+    pub(crate) uri: String,
+
+    /// mailbox is a RefCell containing an optional sender. ActorAddresses may be created from
+    /// just a path, but once a message is sent that path will need to resolve to a mailbox. Once
+    /// the mailbox is resolved, it can be stored here for future use.
+    pub(crate) mailbox: RefCell<Option<Sender<Box<dyn prost::Message>>>>,
+}
+
+impl Clone for ActorAddress {
+    fn clone(&self) -> Self {
+        Self {
+            uri: self.uri.clone(),
+            mailbox: RefCell::new(self.mailbox.borrow().clone()),
+        }
+    }
+}
+
+impl ActorAddress {
+    pub(crate) fn new_child(parent: &ActorAddress, name: &String) -> Self {
+        let uri = format!("{}/{}", parent.uri, name);
+        Self {
+            uri,
+            mailbox: RefCell::new(None),
+        }
+    }
+
+    pub(crate) fn new_root(name: &String) -> Self {
+        let uri = format!("local:/{}", name);
+        Self {
+            uri,
+            mailbox: RefCell::new(None),
+        }
+    }
+
+    // TODO: Implement resolution so this is actually used
+    pub(crate) fn set_mailbox(&self, mailbox: Sender<Box<dyn prost::Message>>) {
+        *self.mailbox.borrow_mut() = Some(mailbox);
+    }
 }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,12 +1,12 @@
 pub(crate) mod thread_executor;
 
-use crate::actor::{Actor, ActorAddress};
+use crate::actor::ActorCell;
 use crate::config::ExecutorType;
 use crate::system::RuntimeManagerRef;
 use crate::util::CommandChannel;
 
 pub enum ExecutorCommands {
-    AssignActor(Box<dyn Actor>, String),
+    AssignActor(ActorCell),
     Shutdown,
 }
 
@@ -24,14 +24,6 @@ pub trait ExecutorFactory {
 
 pub trait Executor {
     fn run(self);
-
-    // Given the name of an actor, return the address local to the executor
-    fn get_address(&self, actor_name: &str) -> ActorAddress;
-
-    // Given an actor, assign the actor to the executor. Note that the implementation
-    // does not require immediate assignment and there may be some delay based on
-    // the particular executor implementation.
-    fn assign_actor(&self, actor: Box<dyn Actor>, name: String);
 }
 
 /// ExecutorHandle contains all the context necessary for the control-thread, which

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,8 +1,9 @@
+use crossbeam_channel::{unbounded, Sender};
 use log::debug;
 use std::collections::HashMap;
 use std::thread;
 
-use crate::actor::{Actor, ActorInit};
+use crate::actor::{Actor, ActorAddress, ActorCell, ActorInit};
 use crate::config;
 use crate::executor::{get_executor_factory, ExecutorCommands, ExecutorFactory, ExecutorHandle};
 use crate::util::CommandChannel;
@@ -77,7 +78,7 @@ impl ActorSystem {
 
         self.root_actor_assigned = true;
         self.runtime_manager
-            .assign_actor(Box::new(A::init(init_msg)), name);
+            .assign_actor(Box::new(A::init(init_msg)), ActorAddress::new_root(&name));
     }
 
     /// Send shutdown message to all executors and wait for them to finish. This includes
@@ -108,6 +109,7 @@ impl ActorSystem {
 struct RuntimeManager {
     /// Map of executor names to their command-channel (for sending commands)
     executor_command_channels: HashMap<String, CommandChannel<ExecutorCommands>>,
+    actor_registry: HashMap<String, Sender<Box<dyn prost::Message>>>,
 
     manager_command_channel: CommandChannel<ManagerCommands>,
 
@@ -119,6 +121,7 @@ impl RuntimeManager {
     fn init() -> RuntimeManager {
         RuntimeManager {
             executor_command_channels: HashMap::new(),
+            actor_registry: HashMap::new(),
             manager_command_channel: CommandChannel::new(),
             round_robin_state: 0,
             shutdown_initiated: false,
@@ -148,7 +151,6 @@ impl RuntimeManager {
                         });
                 }
 
-                // TODO: Actually send this message from the Executors
                 Ok(ManagerCommands::ExecutorShutdown { name }) => {
                     if self.executor_command_channels.contains_key(&name) {
                         self.executor_command_channels.remove(&name);
@@ -157,12 +159,19 @@ impl RuntimeManager {
                         }
                     }
                 }
-                Ok(ManagerCommands::AssignActor(actor, name)) => {
+                Ok(ManagerCommands::AssignActor { actor, address }) => {
                     let executor_name = self.get_next_executor();
+                    let (sender, receiver) = unbounded::<Box<dyn prost::Message>>();
+                    let address_uri = address.uri.clone();
+                    address.set_mailbox(sender.clone());
+                    let cell = ActorCell::new(actor, receiver, address);
+
+                    self.actor_registry.insert(address_uri, sender);
+
                     self.executor_command_channels
                         .get(&executor_name)
                         .unwrap()
-                        .send(ExecutorCommands::AssignActor(actor, name))
+                        .send(ExecutorCommands::AssignActor(cell))
                         .unwrap();
                 }
                 Err(_) => {}
@@ -216,9 +225,9 @@ impl RuntimeManagerRef {
     /// Request that a new actor be assigned to a runtime executor. This may be called when assigning
     /// either a root actor or a child actor. This should be used to avoid blocking actor creation
     /// on a single executor.
-    pub fn assign_actor(&self, actor: Box<dyn Actor>, name: String) {
+    pub fn assign_actor(&self, actor: Box<dyn Actor>, address: ActorAddress) {
         self.manager_command_channel
-            .send(ManagerCommands::AssignActor(actor, name))
+            .send(ManagerCommands::AssignActor { actor, address })
             .unwrap();
     }
 }
@@ -233,6 +242,12 @@ enum ManagerCommands {
     /// Notification from an executor (identified by the name field) that it has completed shutdown
     ExecutorShutdown { name: String },
 
-    /// Requests that a newly created actor be assigned to an executor
-    AssignActor(Box<dyn Actor>, String),
+    /// A request that a newly constructed `Actor` be "realized" in the actor system.
+    ///   + Wrap the actor into an `ActorCell` with a mailbox and address
+    ///   + Store the `ActorAddress` in a global registry for address resolution
+    ///   + Assign the actor to an executor
+    AssignActor {
+        actor: Box<dyn Actor>,
+        address: ActorAddress,
+    },
 }


### PR DESCRIPTION
### Summary

__Implement `ActorAddress` resolution__
    
Added a method to the `RuntimeManagerRef` that can communicate with the management thread in a pseudo-blocking mechanism (only blocks the calling thread) in order to perform address resolution.

This should be sufficient once implementing message sending to locate the right place to send a message and cache the `Sender` in the `ActorAddress`.

__Implementing `ActorCell` and basic addressing__

+ Commands issued from management thread now package up assignment details (actor, address, mailbox) into an `ActorCell`.
+ Addresses are defined as heirarchical and created locally to where the actor is created.
+ Addresses updated with internal state to cache the `Sender` once the address is "resolved"
+ Global lookup of address -> mailbox added to the management thread's internal state.
+ Assignment and address related methods removed from the executor trait (and thread impl)



### Motivation

Implementing the address and address resolution resolves #32. Implementing the `ActorCell` is an implementation both for address/address-resolution (#32) but also necessary for general message sending (#11).

### Test Plan

Examples still run.