### PR TITLE
Message unwrapping/pattern matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   + Implemented `ActorCell`
   + Implemented `ActorAddress` (for local routing only) and address resolution
   + Basic message sending
+  + Pattern matching on received types (by use of `Any`) added. Uses newly
+    added `Message` type (which subsumes `prost::Message`) to implement `as_any()`.
 
 ## 0.1.1
 

--- a/examples/hello_world/main.rs
+++ b/examples/hello_world/main.rs
@@ -2,6 +2,8 @@ extern crate busan;
 
 use busan::actor::{Actor, ActorInit};
 use busan::config::ActorSystemConfig;
+use busan::message::common_types::StringWrapper;
+use busan::message::Message;
 use busan::system::ActorSystem;
 use std::thread;
 
@@ -24,6 +26,12 @@ struct Greet {
     greeting: String,
 }
 
+impl Message for hello_world::actor::Init {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
 impl ActorInit for Greet {
     type Init = hello_world::actor::Init;
 
@@ -40,7 +48,10 @@ impl Actor for Greet {
         println!("{}", self.greeting);
     }
 
-    fn receive(&mut self, _ctx: busan::actor::Context, _msg: Box<dyn prost::Message>) {
-        println!("received message");
+    fn receive(&mut self, _ctx: busan::actor::Context, _msg: Box<dyn Message>) {
+        match _msg.as_any().downcast_ref::<StringWrapper>() {
+            Some(msg) => println!("received message: {}", msg.value),
+            None => {}
+        }
     }
 }

--- a/examples/ping_pong/main.rs
+++ b/examples/ping_pong/main.rs
@@ -2,7 +2,8 @@ extern crate busan;
 
 use busan::actor::{Actor, ActorAddress, ActorInit, Context};
 use busan::config::ActorSystemConfig;
-use busan::message::ToMessage;
+use busan::message::common_types::{I32Wrapper, StringWrapper};
+use busan::message::{Message, ToMessage};
 use busan::system::ActorSystem;
 use std::any::Any;
 use std::thread;
@@ -15,7 +16,7 @@ struct Pong {
 }
 
 impl ActorInit for Ping {
-    type Init = ();
+    type Init = I32Wrapper;
 
     fn init(_init_msg: &Self::Init) -> Self
     where
@@ -27,7 +28,7 @@ impl ActorInit for Ping {
 }
 
 impl ActorInit for Pong {
-    type Init = ();
+    type Init = I32Wrapper;
 
     fn init(_init_msg: &Self::Init) -> Self
     where
@@ -40,11 +41,12 @@ impl ActorInit for Pong {
 
 impl Actor for Ping {
     fn before_start(&mut self, mut ctx: Context) {
-        self.pong_addr = Some(ctx.spawn_child::<_, Pong>("pong".to_string(), &()));
+        self.pong_addr =
+            Some(ctx.spawn_child::<_, Pong>("pong".to_string(), &I32Wrapper::default()));
         ctx.send_message(&self.pong_addr.as_ref().unwrap(), "ping".to_message());
     }
 
-    fn receive(&mut self, ctx: Context, _msg: Box<dyn prost::Message>) {
+    fn receive(&mut self, ctx: Context, _msg: Box<dyn Message>) {
         println!("received message");
         // assume it was a pong, send a ping
         match &self.pong_addr {
@@ -54,10 +56,13 @@ impl Actor for Ping {
     }
 }
 impl Actor for Pong {
-    fn receive(&mut self, ctx: Context, msg: Box<dyn prost::Message>) {
+    fn receive(&mut self, ctx: Context, _msg: Box<dyn Message>) {
         println!("received message");
-
         // assume it was a ping, send a pong
+        match _msg.as_any().downcast_ref::<StringWrapper>() {
+            Some(msg) => println!("received message: {}", msg.value),
+            None => {}
+        }
         match &self.ping_addr {
             Some(addr) => ctx.send_message(&addr, "pong".to_message()),
             None => {}
@@ -65,17 +70,9 @@ impl Actor for Pong {
     }
 }
 
-impl Pong {
-    fn receive2(&mut self, msg: Box<dyn prost::Message + 'static>) {
-        // Convert msg from Box<dyn prost::Message> to Box<Any>
-        // let any_msg: Box<dyn Any> = msg.downcast::<Box<dyn Any>>().unwrap();
-        let any_msg: Box<dyn Any> = msg.downcast::<Box<dyn Any>>().unwrap();
-    }
-}
-
 fn main() {
     let mut system = ActorSystem::init(ActorSystemConfig::default());
-    system.spawn_root_actor::<_, Ping>("ping".to_string(), &());
+    system.spawn_root_actor::<_, Ping>("ping".to_string(), &I32Wrapper::default());
 
     thread::sleep(std::time::Duration::from_secs(1));
     system.shutdown();

--- a/examples/ping_pong/main.rs
+++ b/examples/ping_pong/main.rs
@@ -4,6 +4,7 @@ use busan::actor::{Actor, ActorAddress, ActorInit, Context};
 use busan::config::ActorSystemConfig;
 use busan::message::ToMessage;
 use busan::system::ActorSystem;
+use std::any::Any;
 use std::thread;
 
 struct Ping {
@@ -53,13 +54,22 @@ impl Actor for Ping {
     }
 }
 impl Actor for Pong {
-    fn receive(&mut self, ctx: Context, _msg: Box<dyn prost::Message>) {
+    fn receive(&mut self, ctx: Context, msg: Box<dyn prost::Message>) {
         println!("received message");
+
         // assume it was a ping, send a pong
         match &self.ping_addr {
             Some(addr) => ctx.send_message(&addr, "pong".to_message()),
             None => {}
         }
+    }
+}
+
+impl Pong {
+    fn receive2(&mut self, msg: Box<dyn prost::Message + 'static>) {
+        // Convert msg from Box<dyn prost::Message> to Box<Any>
+        // let any_msg: Box<dyn Any> = msg.downcast::<Box<dyn Any>>().unwrap();
+        let any_msg: Box<dyn Any> = msg.downcast::<Box<dyn Any>>().unwrap();
     }
 }
 

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,3 +1,4 @@
+use crate::message::Message;
 use crate::system::RuntimeManagerRef;
 use crossbeam_channel::{Receiver, Sender};
 use std::cell::RefCell;
@@ -7,14 +8,14 @@ use std::fmt::{Display, Formatter};
 pub trait Actor: Send {
     fn before_start(&mut self, _ctx: Context) {}
 
-    fn receive(&mut self, ctx: Context, msg: Box<dyn prost::Message>);
+    fn receive(&mut self, ctx: Context, msg: Box<dyn Message>);
 }
 
 /// ActorInit defines a method of construction for an actor that takes an initialization
 /// message. This provides type-safe initialization of an actor while keeping construction
 /// and internal state within the actor system.
 pub trait ActorInit {
-    type Init: prost::Message;
+    type Init: Message;
 
     fn init(init_msg: &Self::Init) -> Self
     where
@@ -22,7 +23,7 @@ pub trait ActorInit {
 }
 
 // NOTE:
-//   - Sending messages should always be a prost::Message
+//   - Sending messages should always be a Message
 //   - Receiving messages could be an Any type which _should_ allow for better pattern matching
 //     against expected types. See:
 //     https://stackoverflow.com/questions/26126683/how-to-match-trait-implementors
@@ -31,7 +32,7 @@ pub trait ActorInit {
 /// and other actor-related information that is useful internally.
 pub struct ActorCell {
     pub(crate) actor: Box<dyn Actor>,
-    pub(crate) mailbox: Receiver<Box<dyn prost::Message>>,
+    pub(crate) mailbox: Receiver<Box<dyn Message>>,
     pub(crate) address: ActorAddress,
 
     // Count of children that the actor has spawned. This is used to ensure that the actor names
@@ -42,7 +43,7 @@ pub struct ActorCell {
 impl ActorCell {
     pub fn new(
         actor: Box<dyn Actor>,
-        mailbox: Receiver<Box<dyn prost::Message>>,
+        mailbox: Receiver<Box<dyn Message>>,
         address: ActorAddress,
     ) -> Self {
         Self {
@@ -78,7 +79,7 @@ impl Context<'_> {
         address
     }
 
-    pub fn send_message(&self, addr: &ActorAddress, message: Box<dyn prost::Message>) {
+    pub fn send_message(&self, addr: &ActorAddress, message: Box<dyn Message>) {
         // Validate that the address is resolved (this is a blocking call to the runtime
         // manager if unresolved).
         if !addr.is_resolved() {
@@ -108,7 +109,7 @@ pub struct ActorAddress {
     /// mailbox is a RefCell containing an optional sender. ActorAddresses may be created from
     /// just a path, but once a message is sent that path will need to resolve to a mailbox. Once
     /// the mailbox is resolved, it can be stored here for future use.
-    pub(crate) mailbox: RefCell<Option<Sender<Box<dyn prost::Message>>>>,
+    pub(crate) mailbox: RefCell<Option<Sender<Box<dyn Message>>>>,
 }
 
 impl Display for ActorAddress {
@@ -143,7 +144,7 @@ impl ActorAddress {
         }
     }
 
-    pub(crate) fn set_mailbox(&self, mailbox: Sender<Box<dyn prost::Message>>) {
+    pub(crate) fn set_mailbox(&self, mailbox: Sender<Box<dyn Message>>) {
         *self.mailbox.borrow_mut() = Some(mailbox);
     }
 
@@ -151,7 +152,7 @@ impl ActorAddress {
         self.mailbox.borrow().is_some()
     }
 
-    pub(crate) fn send(&self, message: Box<dyn prost::Message>) {
+    pub(crate) fn send(&self, message: Box<dyn Message>) {
         let result = (&self.mailbox.borrow().as_ref().unwrap()).send(message);
         // TODO: Handle a non-OK error (once actor shutdown is implemented) On error, should
         //       redirect to the dead letter queue. This function may simply return an error

--- a/src/message/common_types.rs
+++ b/src/message/common_types.rs
@@ -1,5 +1,5 @@
 use crate::message;
-use crate::message::ToMessage;
+use crate::message::{Message, ToMessage};
 
 include!(concat!(env!("OUT_DIR"), "/message.common_types.rs"));
 
@@ -9,7 +9,7 @@ macro_rules! impl_to_message_for_primitive {
     };
     ($t:ty, $wrapper:ident, $converter:expr $(, $deref:tt)?) => {
         impl ToMessage for $t {
-            fn to_message(self) -> Box<dyn prost::Message> {
+            fn to_message(self) -> Box<dyn Message> {
                 Box::new($wrapper {
                     value: $converter($($deref)* self),
                 })
@@ -51,7 +51,7 @@ macro_rules! impl_to_message_for_primitive_list {
     // Owned types that don't need conversion
     ($t:ty, $wrapper:ident) => {
         impl ToMessage for Vec<$t> {
-            fn to_message(self) -> Box<dyn prost::Message> {
+            fn to_message(self) -> Box<dyn Message> {
                 Box::new($wrapper { values: self })
             }
         }
@@ -59,7 +59,7 @@ macro_rules! impl_to_message_for_primitive_list {
     // Owned types that need conversion
     ($t:ty, $wrapper:ident, $converter:expr) => {
         impl ToMessage for Vec<$t> {
-            fn to_message(self) -> Box<dyn prost::Message> {
+            fn to_message(self) -> Box<dyn Message> {
                 Box::new($wrapper {
                     values: self.iter().map(|x| $converter(*x)).collect(),
                 })
@@ -69,7 +69,7 @@ macro_rules! impl_to_message_for_primitive_list {
     // Borrowed types that don't need conversion
     (&$t:ty, $wrapper:ident, clone) => {
         impl ToMessage for Vec<$t> {
-            fn to_message(self) -> Box<dyn prost::Message> {
+            fn to_message(self) -> Box<dyn Message> {
                 Box::new($wrapper {
                     values: self.clone(),
                 })
@@ -79,7 +79,7 @@ macro_rules! impl_to_message_for_primitive_list {
     // Borrowed types that need conversion
     (&$t:ty, $wrapper:ident, $converter:expr) => {
         impl ToMessage for Vec<$t> {
-            fn to_message(self) -> Box<dyn prost::Message> {
+            fn to_message(self) -> Box<dyn Message> {
                 Box::new($wrapper {
                     values: self.iter().map(|x| $converter(x)).collect(),
                 })
@@ -102,3 +102,30 @@ impl_to_message_for_primitive_list!(bool, BoolListWrapper);
 impl_to_message_for_primitive_list!(String, StringListWrapper);
 impl_to_message_for_primitive_list!(&String, StringListWrapper, |x: &String| x.clone());
 impl_to_message_for_primitive_list!(&str, StringListWrapper, |x: &str| x.to_string());
+
+macro_rules! impl_busan_message {
+    ($t:ty) => {
+        impl Message for $t {
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+        }
+    };
+}
+
+impl_busan_message!(U32Wrapper);
+impl_busan_message!(U64Wrapper);
+impl_busan_message!(I32Wrapper);
+impl_busan_message!(I64Wrapper);
+impl_busan_message!(FloatWrapper);
+impl_busan_message!(DoubleWrapper);
+impl_busan_message!(BoolWrapper);
+impl_busan_message!(StringWrapper);
+impl_busan_message!(U32ListWrapper);
+impl_busan_message!(U64ListWrapper);
+impl_busan_message!(I32ListWrapper);
+impl_busan_message!(I64ListWrapper);
+impl_busan_message!(FloatListWrapper);
+impl_busan_message!(DoubleListWrapper);
+impl_busan_message!(BoolListWrapper);
+impl_busan_message!(StringListWrapper);

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -1,7 +1,11 @@
 pub mod common_types;
 
+pub trait Message: prost::Message {
+    fn as_any(&self) -> &dyn std::any::Any;
+}
+
 pub trait ToMessage {
-    fn to_message(self) -> Box<dyn prost::Message>;
+    fn to_message(self) -> Box<dyn Message>;
 
     fn is_primitive<L: private::IsLocal>(&self) -> bool {
         return false;


### PR DESCRIPTION
### Summary

Implement method unwrapping and pattern matching by making use of the `Any` type. In order to make this work, I needed a way to cast a trait-object (`Box<dyn prost::Message>`) into Any so that I can pattern-match against concrete types. I accomplished this by replacing the use of `prost::Message` with my own `Message` trait that had a method `as_any(&self) -> &Any` (and using `prost::Message` as a super-trait).

This works and allows for type-safe, runtime pattern matching.

### Motivation

#11

### Test Plan

Currently relying on the example projects to test (they compile and I run them manually to validate).


### Notes

A few thoughts after working through this implementation:

  + Need to land the derive proc-macro
    + Having to implement `Message` is a bit of a joke, it has a method that is always the same
    + I have this locally, but couldn't use it in `busan` because of I think some circular dependencies with the build-deps (macro generates a trait defined in the crate the build.rs is acting on)
    + The example projects should probably be broken out by workspaces so that they can consume the full set of deps like a normal application would (deps, build-deps, macros, separate build.rs and proto-import scope, etc)
  + `Any` seems like a perfectly fine way to have type-safe runtime, type-based pattern matching. But I might be missing context and perhaps this is an anti-pattern? While I expect that _exposing_ users to an API involving `Any` would be an anti-pattern, more context may be needed.
    + Is a decision log warranted here?

<hr />

Some notes that were relevant to me while working on this change, keeping for posterity.

+ `Any` might be a good way to pattern-match here (and offers a type-safe interface to do so)
+ I can't convert from `Box<dyn prost::Message>` to `Box<dyn Any>`
+ I _can_ convert from a trait to a concrete type if there is a `into_any()` method ([SO post][so_post])
+ I _can_ add a custom derrive attribute to generated prost messages ([discussion][prost_issue], [API][attr_api])
+ I _could_ provide my own plugin/API/methods to the build-plugin so that users of the framework just have this availab.e

  [so_post]: https://stackoverflow.com/questions/33687447/how-to-get-a-reference-to-a-concrete-type-from-a-trait-object
  [prost_issue]: https://github.com/tokio-rs/prost/issues/675
  [attr_api]: https://docs.rs/prost-build/latest/prost_build/struct.Config.html#method.type_attribute