### PR TITLE
Derive proc-macro for busan::message::Message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ Cargo.lock
 # Editor Files
 .idea/
 .vscode/
+
+# Allow for a local TODO file that's not tracked in the repo. The overall project
+# should be managed by a proper project-management tool, but per-task TODO's are
+# also useful
+/todo.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   + Basic message sending
   + Pattern matching on received types (by use of `Any`) added. Uses newly
     added `Message` type (which subsumes `prost::Message`) to implement `as_any()`.
+  + Added `busan-derive` with support for `#[derive(busan::Message)]` proc-macro
+  + Updated `hello_world` example to use derive macro in `build.rs`
 
 ## 0.1.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ autoexamples = false
 
 [workspace]
 members = [
+    "busan-derive",
+
     "examples/hello_world",
     "examples/ping_pong",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ log = "0.4"
 num_cpus = "1.13"
 prost = "0.11"
 prost-types = "0.11"
+busan-derive = { path = "busan-derive" }
 
 [build-dependencies]
 prost-build = "0.11"

--- a/busan-derive/Cargo.toml
+++ b/busan-derive/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "busan-derive"
+version = "0.1.0"
+edition = "2021"
+authors = ["John Murray"]
+license-file = "../LICENSE"
+readme = "README.md"
+homepage = "https://github.com/JohnMurray/busan"
+repository = "https://github.com/JohnMurray/busan"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0"
+quote = "1.0"

--- a/busan-derive/README.md
+++ b/busan-derive/README.md
@@ -1,0 +1,3 @@
+# busan-derive
+
+`busan-derive` handles the `#[derive(::busan::Message)]` macro.

--- a/busan-derive/src/lib.rs
+++ b/busan-derive/src/lib.rs
@@ -1,0 +1,21 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(Message)]
+pub fn message(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let name = &ast.ident;
+
+    let expanded = quote! {
+        impl ::busan::message::Message for #name {
+            fn as_any(&self) -> &dyn ::std::any::Any {
+                self
+            }
+        }
+    };
+
+    proc_macro::TokenStream::from(expanded)
+}

--- a/examples/hello_world/build.rs
+++ b/examples/hello_world/build.rs
@@ -1,6 +1,9 @@
 use std::io::Result;
 
 fn main() -> Result<()> {
-    prost_build::compile_protos(&["src/hello_world.proto"], &["src/"])?;
+    let mut config = prost_build::Config::new();
+    config
+        .type_attribute(".", "#[derive(::busan::Message)]")
+        .compile_protos(&["src/hello_world.proto"], &["src/"])?;
     Ok(())
 }

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 use busan::actor::{Actor, ActorInit};
 use busan::config::ActorSystemConfig;
 use busan::message::common_types::StringWrapper;
@@ -5,10 +6,10 @@ use busan::message::Message;
 use busan::system::ActorSystem;
 use std::thread;
 
-mod hello_world {
+mod proto {
     include!(concat!(env!("OUT_DIR"), "/hello_world.rs"));
 }
-use hello_world::*;
+use proto::*;
 
 fn main() {
     let mut system = ActorSystem::init(ActorSystemConfig::default());
@@ -23,12 +24,6 @@ fn main() {
 
 struct Greet {
     greeting: String,
-}
-
-impl Message for Init {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 impl ActorInit for Greet {

--- a/examples/ping_pong/src/main.rs
+++ b/examples/ping_pong/src/main.rs
@@ -1,11 +1,9 @@
-extern crate busan;
-
+#![allow(non_snake_case)]
 use busan::actor::{Actor, ActorAddress, ActorInit, Context};
 use busan::config::ActorSystemConfig;
 use busan::message::common_types::{I32Wrapper, StringWrapper};
 use busan::message::{Message, ToMessage};
 use busan::system::ActorSystem;
-use std::any::Any;
 use std::thread;
 
 struct Ping {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,9 @@ pub mod executor;
 pub mod message;
 pub mod system;
 pub mod util;
+
+#[allow(unused_imports)]
+#[macro_use]
+extern crate busan_derive;
+#[doc(hidden)]
+pub use busan_derive::Message;

--- a/todo.md
+++ b/todo.md
@@ -1,3 +1,0 @@
-+ [ ] Basic types (int, float, bool, string, etc)
-+ [ ] Lists of basic types (vec<T> where T: basic-type)
-+ [ ] Tuples of T where T: basic-type


### PR DESCRIPTION
### Summary

Adds a new package `busan-derive` that defines a derive proc-macro for deriving implementations of `busan::messages::Message`.

Updates the `hello_world` example to make use of the macro by adding it to generated code created in `build.rs`.

### Motivation

#11

The `Message` trait is a requirement for pattern matching, but is an _additional_ trait on top of `prost::Message` (or possibly some other serialization trait), and there are already patterns for generating code with prost (either via `prost-derive` or `prost-build` packages).

Having a derive macro allows users the same flexibility to either use the macro directly, or do define an additional macro be inserted on generated code.

### Test Plan

CI is sufficient as the `hello_world` examples makes use of the new compile-time features.