### PR TITLE
Unsupported message type handler

### DIFF
--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -42,10 +42,10 @@ impl Actor for Greet {
         println!("{}", self.greeting);
     }
 
-    fn receive(&mut self, _ctx: busan::actor::Context, _msg: Box<dyn Message>) {
-        match _msg.as_any().downcast_ref::<StringWrapper>() {
+    fn receive(&mut self, ctx: busan::actor::Context, msg: Box<dyn Message>) {
+        match msg.as_any().downcast_ref::<StringWrapper>() {
             Some(msg) => println!("received message: {}", msg.value),
-            None => {}
+            None => self.unhandled(ctx, msg),
         }
     }
 }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -20,7 +20,7 @@ pub trait Actor: Send {
         warn!(
             "{}: unhandled message: ({} bytes)",
             ctx.address.uri,
-            msg.encoded_len()
+            Message::encoded_len(msg.as_ref()),
         );
     }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -2,6 +2,11 @@ pub mod common_types;
 
 pub trait Message: prost::Message {
     fn as_any(&self) -> &dyn std::any::Any;
+
+    #[doc(hidden)]
+    fn encoded_len(&self) -> usize {
+        prost::Message::encoded_len(self)
+    }
 }
 
 pub trait ToMessage {


### PR DESCRIPTION
### Summary

Adds and `unhandled` method to the `Actor` trait. The method should be called by the Actor when it is unable to process an incoming message. The new method currently emits warning log messages, but will eventually be wried up to the dead-letter queue.

### Motivation

Handling unexpected/unknown messages is a core part of the API and this satisfies that API surface while leaving the implementation as mostly a TODO.

### Test Plan

Compilation and usage in the example is currently sufficient. This may no longer be sufficient once the dead-letter queue system is built.