### PR TITLE
actor creation - use ToMessage<M>

### DIFF
--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
     let init = Init {
         greeting: "Hi there!".to_string(),
     };
-    system.spawn_root_actor::<_, Greet>("greeter", &init);
+    system.spawn_root_actor::<Greet, _, _>("greeter", init);
 
     thread::sleep(std::time::Duration::from_secs(1));
     system.shutdown();
@@ -28,7 +28,7 @@ struct Greet {
 impl ActorInit for Greet {
     type Init = Init;
 
-    fn init(init_msg: &Self::Init) -> Self {
+    fn init(init_msg: Self::Init) -> Self {
         println!("spawning greet actor");
         Greet {
             greeting: init_msg.greeting.clone(),

--- a/examples/ping_pong/src/main.rs
+++ b/examples/ping_pong/src/main.rs
@@ -11,7 +11,7 @@ struct Pong {}
 impl ActorInit for Ping {
     type Init = I32Wrapper;
 
-    fn init(_init_msg: &Self::Init) -> Self
+    fn init(_init_msg: Self::Init) -> Self
     where
         Self: Sized + Actor,
     {
@@ -23,7 +23,7 @@ impl ActorInit for Ping {
 impl ActorInit for Pong {
     type Init = I32Wrapper;
 
-    fn init(_init_msg: &Self::Init) -> Self
+    fn init(_init_msg: Self::Init) -> Self
     where
         Self: Sized + Actor,
     {
@@ -34,7 +34,7 @@ impl ActorInit for Pong {
 
 impl Actor for Ping {
     fn before_start(&mut self, mut ctx: Context) {
-        let pong_addr = Some(ctx.spawn_child::<_, Pong>("pong", &I32Wrapper::default()));
+        let pong_addr = Some(ctx.spawn_child::<Pong, _, _>("pong", 0));
         ctx.send_message(pong_addr.as_ref().unwrap(), "ping");
     }
 
@@ -62,7 +62,7 @@ fn main() {
         .init();
 
     let mut system = ActorSystem::init(ActorSystemConfig::default());
-    system.spawn_root_actor::<_, Ping>("ping", &I32Wrapper::default());
+    system.spawn_root_actor::<Ping, _, _>("ping", 0);
 
     thread::sleep(std::time::Duration::from_secs(1));
     system.shutdown();

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -50,7 +50,7 @@
 //!
 //! impl ActorInit for Greeter {
 //!   type Init = GreeterInit;
-//!   fn init(init_msg: &Self::Init) -> Self {
+//!   fn init(init_msg: Self::Init) -> Self {
 //!     let mut phrase = init_msg.phrase.clone();
 //!     if phrase.is_empty() {
 //!       phrase = "Hello".to_string();

--- a/src/system.rs
+++ b/src/system.rs
@@ -42,11 +42,11 @@ impl ActorSystem {
     /// # }
     /// # impl ActorInit for GreetActor{
     /// #     type Init = StringWrapper;
-    /// #     fn init(init_msg: &StringWrapper) -> Self { GreetActor{ value: init_msg.value.clone()} }
+    /// #     fn init(init_msg: StringWrapper) -> Self { GreetActor{ value: init_msg.value.clone()} }
     /// # }
     /// fn main() {
     ///   let mut system = ActorSystem::init(ActorSystemConfig::default());
-    ///   system.spawn_root_actor::<_, GreetActor>("greet-actor", &"World".to_message());
+    ///   system.spawn_root_actor::<GreetActor, _, _>("greet-actor", "World");
     ///   system.shutdown();
     /// }
     /// ```

--- a/src/system.rs
+++ b/src/system.rs
@@ -5,6 +5,8 @@ use std::thread;
 
 use crate::actor::{Actor, ActorAddress, ActorCell, ActorInit, Letter, Uri};
 use crate::executor::{get_executor_factory, ExecutorCommands, ExecutorHandle};
+use crate::message::ToMessage;
+use crate::prelude::Message;
 use crate::util::CommandChannel;
 use crate::{actor, config};
 
@@ -86,10 +88,14 @@ impl ActorSystem {
     /// of the actor hierarchy and all other actors must be created from here. Note that
     /// there may only be a single root actor per system and can, in some ways, be considered
     /// the "main" function of the actor system.
-    pub fn spawn_root_actor<B, A: ActorInit<Init = B> + Actor + 'static>(
+    pub fn spawn_root_actor<
+        A: ActorInit<Init = M> + Actor + 'static,
+        T: ToMessage<M>,
+        M: Message,
+    >(
         &mut self,
         name: &str,
-        init_msg: &B,
+        init_msg: T,
     ) {
         debug_assert!(
             !self.executors.is_empty(),
@@ -99,7 +105,7 @@ impl ActorSystem {
 
         self.root_actor_assigned = true;
         self.runtime_manager.assign_actor(
-            Box::new(A::init(init_msg)),
+            Box::new(A::init(init_msg.to_message())),
             ActorAddress::new_root(name),
             None,
         );


### PR DESCRIPTION
### Summary

Use `ToMessage<M>` when creating an actor.

### Motivation

+ Matches the API for sending messages
+ Additional ergonomic benefits to values passed in, particularly for primitives.

This has an ergonomics _cost_, however, in the signature now having three generics. Adding this to my punch-list of ergonomics issues to revisit later.

### Test Plan

+ [x] Examples
+ [x] doc-tests (more examples)