### PR TITLE
Update documentation and licensing info in README.md

### DIFF
--- a/.github/workflows/cspell.json
+++ b/.github/workflows/cspell.json
@@ -25,6 +25,7 @@
         "proto",
         "protobuf",
         "protos",
+        "rustdocs",
         "snapshotting",
         "struct"
     ],

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ it usable to build hobby/personal projects on.
 
 ## Documentation
 
-The project lacks comprehensive documentation at this time, however I am experimenting with [decision
-logs][decision-log-url] as a way to document and communicate the major design decisions that were
-made.
+The project lacks comprehensive documentation or getting started guides at this time. The best
+source of documentation will be found in the rustdocs at [docs.rs][docs-rs-busan] and in the
+[examples folder][examples-url].
 
-Of course the source code is also lightly documented and available at [docs.rs][docs-rs-busan]
-and there are fully functional examples available in the [examples folder][examples-url].
+If you are interested in additional context behind the project or technical decisions, then the
+[decision logs][decision-log-url] may be of particular interest.
 
   [docs-rs-busan]: https://docs.rs/busan/latest/busan/
   [examples-url]: https://github.com/JohnMurray/busan/blob/main/examples/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ If you are interested in additional context behind the project or technical deci
   [docs-rs-busan]: https://docs.rs/busan/latest/busan/
   [examples-url]: https://github.com/JohnMurray/busan/blob/main/examples/
 
+### Examples
+
+You can run the examples by specifying the workspace (directory) name, prefixed with `examples_`.
+
+```shell
+# Run the current examples
+$ cargo run -p examples_ping_pong
+$ cargo run -p examples_hello_world
+
+# Trick the cargo run command into listing our example workspaces
+$ cargo run -p 2>&1 | grep 'examples_' 
+```
+
 ## Roadmap
 
 The roadmap is constantly evolving, so I don't expect plans to be super detailed outside

--- a/README.md
+++ b/README.md
@@ -71,3 +71,11 @@ I'm not currently considering code contributions at the moment as the project is
 and I'm still working out the design. However, I am open to suggestions and feedback. If you have any
 ideas or suggestions, please start a discussion. I'd also be interested in hearing about
 real-world use-cases that are not well-supported by other Rust-based actor implementations.
+
+## Licensing
+
+The project is currently licensed under the [GNU GPL v3][license] license. My intention is to
+ensure all early work and development on this project is kept open. I may revisit this if there
+is significant commercial interest.
+
+  [license]: https://github.com/JohnMurray/busan/blob/main/LICENSE

--- a/examples/ping_pong/Cargo.toml
+++ b/examples/ping_pong/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "examples_ping-pong"
+name = "examples_ping_pong"
 version = "0.0.0"
 publish = false
 edition = "2021"


### PR DESCRIPTION
### Summary

Rephrase the documentation section in the README now that the docs.rs stuff is semi-useful. Also add some bits on how to run the examples since I think that's going to be a decent place to look at code going forward and I expect to add more examples.

Add a section regarding the license at the bottom. I'm not sure if the GPLv3 is super popular and folks may not expect it, so worth pointing out.

### Motivation

README.md was lagging a bit behind the project.

### Test Plan

Spell check in CI