### PR TITLE
add merge2 to busan::message::Message

### DIFF
--- a/busan-derive/src/lib.rs
+++ b/busan-derive/src/lib.rs
@@ -18,6 +18,10 @@ pub fn message(input: TokenStream) -> TokenStream {
             fn encode_to_vec2(&self) -> Vec<u8> {
                 prost::Message::encode_to_vec(self)
             }
+
+            fn merge2(&mut self, bytes: &[u8]) -> Result<(), prost::DecodeError> {
+                prost::Message::merge(self, bytes)
+            }
         }
     };
 

--- a/src/message/common_types.rs
+++ b/src/message/common_types.rs
@@ -112,6 +112,9 @@ macro_rules! impl_busan_message {
             fn encode_to_vec2(&self) -> Vec<u8> {
                 prost::Message::encode_to_vec(self)
             }
+            fn merge2(&mut self, bytes: &[u8]) -> Result<(), prost::DecodeError> {
+                prost::Message::merge(self, bytes)
+            }
         }
     };
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -12,6 +12,10 @@ pub trait Message: prost::Message {
     #[doc(hidden)]
     fn encode_to_vec2(&self) -> Vec<u8>;
 
+    /// A version of merge that does not have a [`Sized`] requirement
+    #[doc(hidden)]
+    fn merge2(&mut self, buf: &[u8]) -> Result<(), prost::DecodeError>;
+
     #[doc(hidden)]
     fn encoded_len(&self) -> usize {
         prost::Message::encoded_len(self)


### PR DESCRIPTION
### Summary

Add `merge2` to `Message` which is a wrapper to `prost::Message::merge`. Added as an undocumented (hidden) method on Message that is primarily an implementation detail internal to busan.

### Motivation

The `Message::merge` function from prost requires that self be `Sized`. `merge2` allows us to call the merge function through dynamic dispatch by implementing `merge2` on the object and not in the trait.

### Test Plan

It compiles. Usages will come later for further testing/refinement.