### PR TITLE
Split message sending into two (complementary) methods

### DIFF
--- a/examples/ping_pong/src/main.rs
+++ b/examples/ping_pong/src/main.rs
@@ -35,14 +35,14 @@ impl ActorInit for Pong {
 impl Actor for Ping {
     fn before_start(&mut self, mut ctx: Context) {
         let pong_addr = Some(ctx.spawn_child::<Pong, _, _>("pong", 0));
-        ctx.send_message(pong_addr.as_ref().unwrap(), "ping");
+        ctx.send(pong_addr.as_ref().unwrap(), "ping");
     }
 
     fn receive(&mut self, ctx: Context, msg: Box<dyn Message>) {
         // Print the message and respond with a "ping"
         if let Some(str_msg) = msg.as_any().downcast_ref::<StringWrapper>() {
             println!("received message: {}", str_msg.value);
-            ctx.send_message(ctx.sender(), "ping");
+            ctx.send(ctx.sender(), "ping");
         }
     }
 }
@@ -51,7 +51,7 @@ impl Actor for Pong {
         // Print the message and respond with a "pong"
         if let Some(str_msg) = msg.as_any().downcast_ref::<StringWrapper>() {
             println!("received message: {}", str_msg.value);
-            ctx.send_message(ctx.sender(), "pong");
+            ctx.send(ctx.sender(), "pong");
         }
     }
 }

--- a/src/actor/actor.rs
+++ b/src/actor/actor.rs
@@ -123,7 +123,7 @@ impl Context<'_> {
 
     // TODO: Document
     // TODO: Talk about the debug_serialize_msg! in the docs
-    pub fn send_message<M: Message + Default + 'static, T: ToMessage<M>>(
+    pub fn send<M: Message + Default + 'static, T: ToMessage<M>>(
         &self,
         addr: &ActorAddress,
         message: T,


### PR DESCRIPTION
### Summary

Split message sending into two methods:

  + `Context::send` - Utility method that takes `ToMessage`, performs conversion and calls `Context::send_message`
  + `Context::send_message` - Takes a `Box<Message>`, resolves the address, performs serialization/deserialization (in debug mode), and transmits the message.

### Motivation

The previous implementation of `send_message` worked by using `ToMessage` as a convenience type to cut down on the boilerplate of sending messages. This worked great, however it had one drawback in that is relied on concrete types.

The ability to also send a `Box<Message>` allows for patterns, abstractions, or middle-men to be built. Take a load-balancer actor for example. It receives `Box<Message>`s and then forwards them to an actor in a pool. In this instance, there is no concrete type we're dealing with so it is difficult to use `ToMessage`.

### Test Plan

The current examples and tests should cover the new use-case as the new method is still in the critical path.