### PR TITLE
support sending ActorAddress objects

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,9 @@
 use std::io::Result;
 
 fn main() -> Result<()> {
-    prost_build::compile_protos(&["src/message/wrappers.proto"], &["src/"])?;
+    prost_build::compile_protos(
+        &["src/message/wrappers.proto", "src/actor/address.proto"],
+        &["src/"],
+    )?;
     Ok(())
 }

--- a/src/actor/address.proto
+++ b/src/actor/address.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package actor.proto;
+
+enum Scheme {
+  LOCAL = 0;
+
+  // Remote is currently a placeholder for future use.
+  // See busan::actor::address::UriScheme
+  REMOTE = 1;
+}
+
+// ActorAddress is the serializable representation of an actor address. It can be used
+// to send an address to another actor for the purpose of discovery and message routing.
+message ActorAddress {
+  Scheme scheme = 1;
+  string path = 2;
+}
+
+// AddressList is a simple container for holding a list of ActorAddress messages.
+// This allows for multiple addresses to be sent as a single message from/to an actor.
+message AddressList {
+  repeated ActorAddress addresses = 1;
+}

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -90,6 +90,8 @@ pub mod address;
 #[doc(hidden)]
 pub mod letter;
 
+pub mod proto;
+
 #[doc(inline)]
 pub use actor::*;
 #[doc(inline)]

--- a/src/actor/proto.rs
+++ b/src/actor/proto.rs
@@ -1,0 +1,54 @@
+//! Serializable message types for the actor module
+//!
+//! This module contains the protobuf definitions that map to internal types
+//! such as [`ActorAddress`](crate::actor::ActorAddress) as well as the associated
+//! [`ToMessage`](crate::message::ToMessage) implementations for these types.
+
+use crate::actor;
+use crate::message::common_types::impl_busan_message;
+use crate::message::{Message, ToMessage};
+use std::cell::RefCell;
+
+// Import the generated protobuf definitions (see build.rs)
+include!(concat!(env!("OUT_DIR"), "/actor.proto.rs"));
+
+impl_busan_message!(ActorAddress);
+impl_busan_message!(AddressList);
+
+impl ToMessage<ActorAddress> for &actor::ActorAddress {
+    fn to_message(self) -> ActorAddress {
+        ActorAddress {
+            scheme: match self.uri.scheme {
+                Scheme::Local => Scheme::Local as i32,
+                Scheme::Remote => Scheme::Remote as i32,
+            },
+            path: self.uri.path(),
+        }
+    }
+}
+
+impl TryFrom<ActorAddress> for actor::ActorAddress {
+    type Error = String;
+
+    fn try_from(address: ActorAddress) -> Result<Self, Self::Error> {
+        let scheme = Scheme::from_i32(address.scheme)
+            .ok_or(format!("Invalid scheme: {}", address.scheme))?;
+        Ok(actor::ActorAddress {
+            // TODO: This needs an internal constructor. Presumably there is at least
+            //       one other place we're doing this same thing
+            uri: actor::Uri {
+                scheme,
+                path_segments: address.path.split('/').map(|s| s.to_string()).collect(),
+            },
+            mailbox: RefCell::new(None),
+        })
+    }
+}
+
+impl ToMessage<AddressList> for &[actor::ActorAddress] {
+    fn to_message(self) -> AddressList {
+        AddressList {
+            addresses: self.iter().map(|a| a.to_message()).collect(),
+        }
+    }
+}

--- a/src/message/common_types.rs
+++ b/src/message/common_types.rs
@@ -118,6 +118,7 @@ macro_rules! impl_busan_message {
         }
     };
 }
+pub(crate) use impl_busan_message;
 
 impl_busan_message!(U32Wrapper);
 impl_busan_message!(U64Wrapper);


### PR DESCRIPTION
### Summary

More or less what the title says. This PR adds the proto messages and necessary trait implementations to send an `ActorAddress` (or a slice of them) as a `busan::message::Message`.

In theory this means they can be serialized and shared across process boundaries, but in reality that would require a bit more work as nothing other than the "local" scheme is supported at the moment.

### Motivation

Sharing addresses unlocks more dynamic messaging patterns as currently it's only possible to send messages between parents and children.

### Test Plan

Nothing ATM. Work on load balancing will make use of and test this further.