### PR TITLE
[actor shutdown] Context method + no-deliver state

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -2,13 +2,14 @@
 
 pub(crate) mod thread_executor;
 
-use crate::actor::ActorCell;
+use crate::actor::{ActorAddress, ActorCell};
 use crate::config::ExecutorType;
 use crate::system::RuntimeManagerRef;
 use crate::util::CommandChannel;
 
 pub enum ExecutorCommands {
     AssignActor(ActorCell),
+    ShutdownActor(ActorAddress),
     Shutdown,
 }
 


### PR DESCRIPTION
### Summary

Adds an initial `shutdown` message to the actor context. This allows an actor to immediately shutdown (only callable from within the actor) and sets some state on the actor so that no new messages are received.

### Motivation

Part of #29.

This is only a small subset of actor shutdown logic, see #29 for full details.

### Test Plan

Still TBD. I'll see how this evolves as shutdown evolves over the course of implementing #29.