### PR TITLE
[actor shutdown] cell state bitmask fix

### DIFF
--- a/.github/workflows/cspell.json
+++ b/.github/workflows/cspell.json
@@ -16,6 +16,7 @@
         "roadmap"
     ],
     "userWords": [
+        "bitmask",
         "busan",
         "cpus",
         "geoip",  // "geo" "IP"


### PR DESCRIPTION
### Summary

When an actor shuts down, the state bitmask in the `ActorCell` is flipped from the `Context` object when a shutdown is requested. Previously this was only set within the executor.

### Motivation

Part of #29 

There is an asynchronous delay between an actor signaling it is shutting down to when the executor sets the state. This is because the request travels through the runtime manager and then back to the executor via async channel communications.

What is described above introduces a window where an actor has signaled shutdown and continues to receive messages. By setting the shutdown flag directly within the actor (as well as within the executor), messages processing by the actor will stop immediately.

### Test Plan

Shutdown testing will be covered in the broader actor shutdown effort.