### PR TITLE
Actor receive macros

### DIFF
--- a/src/actor/actor.rs
+++ b/src/actor/actor.rs
@@ -7,7 +7,6 @@ use crate::util::lib_macros::channel_send;
 use crate::util::CommandChannel;
 use crossbeam_channel::Receiver;
 use log::{trace, warn};
-use std::rc::Weak;
 
 /// Trait that defines the behavior of an actor. This is the primary interface that must be
 /// implemented when defining an actor.
@@ -56,8 +55,6 @@ pub trait Actor: Send {
     fn after_stop(&mut self) {}
 }
 
-type ReceiverFunc = fn(&mut dyn Actor, Context, Box<dyn Message>);
-
 /// ActorInit defines a method of construction for an actor that takes an initialization
 /// message. This provides type-safe initialization of an actor while keeping construction
 /// and internal state within the actor system.
@@ -101,8 +98,6 @@ pub struct ActorCell {
     pub(crate) parent: Option<ActorAddress>,
     pub(crate) state: CellState,
     pub(crate) ack_nonce: u32,
-
-    pub(crate) receiver: &ReceiverFunc,
 }
 
 impl ActorCell {
@@ -112,7 +107,6 @@ impl ActorCell {
         address: ActorAddress,
         parent: Option<ActorAddress>,
     ) -> Self {
-        let receiver: ReceiverFunc = actor.as_ref().receive;
         Self {
             actor,
             mailbox,
@@ -121,7 +115,6 @@ impl ActorCell {
             parent,
             state: 0,
             ack_nonce: 0,
-            receiver,
         }
     }
 }

--- a/src/actor/matcher.rs
+++ b/src/actor/matcher.rs
@@ -1,0 +1,42 @@
+/*
+
+match_message!(msg) {
+    m: MyTypte => {
+
+    },
+}
+
+thoughts:
+- I want the behaviors to seem like they're apart of your actor, not like they
+  are part of some other object. That means having access to the local state.
+- What if:
+    - the macro just defines a function that takes the actor as an input to
+      self.
+    - then the actor (or context) can have a "real_receive" that defaults to
+      the current receive, but can be overriden by calling something like
+      ctx.become(behavior)
+
+- I also want the "receive" function to be able to use the same set of matchers
+*/
+
+/* This is an impl that I started with that's based on behavior "objects" but
+had a flaw in that it can't pull in the local scope of the actor */
+// use crate::actor::Actor;
+// use std::any::Any;
+//
+// pub struct Behavior<T: Actor> {
+//     matcher: fn(&dyn Any) -> bool,
+//     handler: fn(&dyn Any, &mut T) -> (),
+// }
+//
+// impl<T: Actor> Behavior<T> {
+//     // TODO: Remove later, just was pretty annoyed for right now
+//     #[allow(dead_code)]
+//     fn apply(&self, msg: &dyn Any, actor: &mut T) -> bool {
+//         if (self.matcher)(msg) {
+//             (self.handler)(msg, actor);
+//             return true;
+//         }
+//         false
+//     }
+// }

--- a/src/actor/matcher.rs
+++ b/src/actor/matcher.rs
@@ -15,28 +15,107 @@ thoughts:
     - then the actor (or context) can have a "real_receive" that defaults to
       the current receive, but can be overriden by calling something like
       ctx.become(behavior)
+- problem
+    - function pointers are pretty tricky
+        - can't take a function pointer to a method on a trait object
+        - weak references are created with unsafe blocks, and I _really_ want
+          to keep unsafe out of busan in its entirety
 
 - I also want the "receive" function to be able to use the same set of matchers
+
+
+
+Questions
+---------
+  - Is the `self` parameter an actual keyword?
+    - it _is_ a keyword, but it has some flexibility on the type it can be. Update: no it doesn't. Not really.
+    - https://doc.rust-lang.org/std/keyword.self.html
+  - Can I use `self` as a parameter name?
+    - upon investigation, nope. I can't use self unless it refers (direct or indirect) to the "expected" Self type
+
 */
 
 /* This is an impl that I started with that's based on behavior "objects" but
 had a flaw in that it can't pull in the local scope of the actor */
-// use crate::actor::Actor;
-// use std::any::Any;
-//
-// pub struct Behavior<T: Actor> {
-//     matcher: fn(&dyn Any) -> bool,
-//     handler: fn(&dyn Any, &mut T) -> (),
-// }
-//
-// impl<T: Actor> Behavior<T> {
-//     // TODO: Remove later, just was pretty annoyed for right now
-//     #[allow(dead_code)]
-//     fn apply(&self, msg: &dyn Any, actor: &mut T) -> bool {
-//         if (self.matcher)(msg) {
-//             (self.handler)(msg, actor);
-//             return true;
+use crate::actor::Actor;
+use std::any::Any;
+
+pub struct Behavior<T: Actor> {
+    matcher: fn(&dyn Any) -> bool,
+    handler: fn(&mut T, &dyn Any) -> (),
+}
+
+impl<T: Actor> Behavior<T> {
+    // TODO: Remove later, just was pretty annoyed for right now
+    #[allow(dead_code)]
+    fn apply(&self, msg: &dyn Any, actor: &mut T) -> bool {
+        if (self.matcher)(msg) {
+            (self.handler)(actor, msg);
+            return true;
+        }
+        false
+    }
+}
+
+// macro_rules! handle {
+//     ($var:ident : $ty:ty, $b:block) => {
+//         struct T{}
+//         impl Behavior2<$ty> for T {
+//             fn matcher(&self, msg: &dyn Any) -> bool {
+//                 msg.is::<$ty>()
+//             }
+//             fn handler(self: &mut T, msg: &dyn Any) {
+//                 let msg = msg.downcast_ref::<$ty>().unwrap();
+//                 $b
+//             }
 //         }
-//         false
-//     }
+//         let f = |$var: $ty| $b;
+//         let x = 5;
+//         println!("hello, world");
+//         println!("second thing");
+//     };
 // }
+
+pub fn test() {
+    // handle!(self: String, {
+    //     println!("Got a string: {}", self);
+    // });
+    use crate::actor::{ActorInit, Context};
+    use crate::message::common_types::{I32Wrapper, StringWrapper};
+    use crate::message::Message;
+
+    trait Behavior2<T: Actor, M: Message> {
+        fn matcher(&self, msg: &dyn Message) -> bool;
+        fn handler(&mut self, msg: &dyn Message);
+    }
+
+    struct Ping {}
+    impl ActorInit for Ping {
+        type Init = I32Wrapper;
+        fn init(_init_msg: Self::Init) -> Self
+        where
+            Self: Sized + Actor,
+        {
+            Ping {}
+        }
+    }
+    impl Actor for Ping {
+        fn receive(&mut self, ctx: Context, msg: Box<dyn Message>) {
+            // Print the message and respond with a "ping"
+            if let Some(str_msg) = msg.as_any().downcast_ref::<StringWrapper>() {
+                println!("received message: {}", str_msg.value);
+                ctx.send(ctx.sender(), "ping");
+            }
+        }
+    }
+
+    impl Behavior2<Ping, StringWrapper> for Ping {
+        fn matcher(&self, msg: &dyn Message) -> bool {
+            msg.as_any().downcast_ref::<String>().is_some()
+        }
+        fn handler(&mut self, msg: &dyn Message) {
+            let msg = msg.as_any().downcast_ref::<String>().unwrap();
+            println!("Got a string: {}", msg);
+        }
+    }
+}

--- a/src/actor/matcher.rs
+++ b/src/actor/matcher.rs
@@ -207,4 +207,26 @@ Proposal #2
       than the current state and/or having access to `self`
     - Captures on the lambdas might be confusing because the storage for these behaviors
       is going to be outside the actor
+
+
+Proposal #3
+----
+An addition onto Proposal #2 that introduces a few macros to make the
+construction and usage of behaviors easier:
+
+    fn starting_state(&mut self, _: Context) -> BehaviorSet {
+        behaviors![
+            match!<StringWrapper> => |actor, ctx, stringMsg| {
+                println!("received message: {}", stringMsg); // stringMsg is a String
+                ctx.send(ctx.sender(), "ping");
+                actor.become(actor.next_state())  // STATE TRANSITION
+            },
+            default_match! => |actor, ctx, msg| {
+                println!("received message: {:?}", msg);
+            },
+        ]
+    }
+
+
+
 */

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -89,6 +89,8 @@ pub mod actor;
 pub mod address;
 #[doc(hidden)]
 pub mod envelope;
+#[doc(hidden)]
+pub mod matcher;
 
 pub mod proto;
 
@@ -96,6 +98,8 @@ pub mod proto;
 pub use actor::*;
 #[doc(inline)]
 pub use address::*;
+#[doc(inline)]
+pub use matcher::*;
 
 pub(crate) use envelope::*;
 pub(crate) type Mailbox = crossbeam_channel::Sender<Envelope>;


### PR DESCRIPTION
### Summary



### Motivation



### Test Plan

### Notes

Just some thoughts about the work here and some considerations that went into it. What I would like out of actors with respect to message handling in the long-term:

- Behaviors
  - The ability to group message handlers of various types together
  - The ability to switch what the default behavior invoked when receiving a message
  - For this to be part of the basic / default API of an actor

- Ergonomics
  - Not having to deal with type-casting or conversions
  - Ability to write fairly normal looking code

__Approach: Behavior Objects__ \
It makes for a nice abstraction to model behaviors as objects that have a function that checks for message-type map and a function that does the processing. You can create these with macros to hide the ugly construction and then you can group and mix/match different behaviors together for composability.

How this approach lacks mostly has to due with the Rust borrow checker. You want each behavior to have mutable access to actor, but you can't capture this in a lambda. Further you can't pass in a `self` to the behavior of the actor type. So these limitations will add to an awkward API that macros wouldn't be able to fully hide.

__Approach: Function Pointers__ \
Instead of composing individual functions, just allow the user to define multiple "receive" functions and then switch between them at runtime. The default could just use the "receive" function that is already part of the actor trait.

Implementation wise, we would just need to track the function pointer in the `CellState` where we already store actor state and the actor itself.

The limitations again come down to Rust in particular. Function pointers are possible but, you can't take a function pointer to a method on a dyn trait. Also, the borrow checker again makes this a bit hard. We could use weak reference types, but those require the use of `unsafe`, which I want to fully avoid in this project.
